### PR TITLE
bugfix: correct undo/redo behavior in cheat mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,8 @@
         let redoStack = [];
         let level12Undo = false;
         let level12RedoAfterUndo = false;
+        let cheatModeOtherUndo = false;
+        let cheatModeOtherRedoAfterUndo = false;
         let lastExCommand = null;
         let searchMode = false;
         let searchQuery = '';
@@ -908,7 +910,11 @@
                 if (currentLines.length === targetLines.length && currentLines.every((l, i) => l === targetLines[i])) {
                     if (level.name === 'Undo / Redo') {
                         if (level12RedoAfterUndo) won = true;
-                    } else {
+                    } 
+                    else if (level.name === 'Practice: u / Ctrl+r'){
+                        if (cheatModeOtherUndo && cheatModeOtherRedoAfterUndo) won = true;
+                    }
+                    else {
                         won = true;
                     }
                 }
@@ -1110,6 +1116,9 @@
                 }
                 if (levels[currentLevel].name === 'Undo / Redo' && level12Undo) {
                     level12RedoAfterUndo = true;
+                }
+                if(levels[currentLevel].name === 'Practice: u / Ctrl+r') {
+                    cheatModeOtherRedoAfterUndo = true;
                 }
                 renderEditor();
                 checkWinCondition();
@@ -1358,6 +1367,10 @@
                 if (levels[currentLevel].name === 'Undo / Redo') {
                     level12Undo = true;
                     level12RedoAfterUndo = false;
+                }
+                if(levels[currentLevel].name === 'Practice: u / Ctrl+r') {
+                    cheatModeOtherUndo = true;
+                    cheatModeOtherRedoAfterUndo = false;
                 }
                 renderEditor();
                 checkWinCondition();


### PR DESCRIPTION
**Issue**
In "Cheat Mode > Other > Undo / Redo", there is a bug in the keyboard shortcut flow.

**Expected Behavior**
After dd > u > Ctrl+R, the application should properly perform undo followed by redo.

**Actual Behavior**
Only the dd command is executed, and then the application directly opens the sidebar instead of performing undo/redo.

**Fix**
Fixed the Undo/Redo logic in Cheat Mode so the "dd > u > Ctrl+R" sequence works as expected.

**Note**
If there will be more challenges or cheat modes using undo/redo in the future, it is recommended to implement a dedicated logic to avoid having too many conditionals.