### PR TITLE
docs: governance, vision, and contributor infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: 🐛 Bug report
+description: Something is broken in the game or the site
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time! A good repro is half the fix.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, what happened instead?
+      placeholder: |
+        1. Open level 5 (Delete Basics)
+        2. Press dd on line 2
+        3. Expected the line to be deleted; instead …
+    validations:
+      required: true
+  - type: input
+    id: level
+    attributes:
+      label: Level / mode
+      description: Which level, challenge, or mode (Cheat Mode, Challenge Mode, profile page)?
+      placeholder: "Level 5 — Delete Basics"
+  - type: textarea
+    id: keys
+    attributes:
+      label: Exact key sequence (if relevant)
+      description: The keystrokes that trigger the bug, in order.
+      placeholder: "j dd u Ctrl+r"
+  - type: input
+    id: browser
+    attributes:
+      label: Browser & OS
+      placeholder: "Firefox 128 / Windows 11"
+    validations:
+      required: true
+  - type: textarea
+    id: console
+    attributes:
+      label: Console errors
+      description: Open DevTools (F12) → Console, paste anything red.
+      render: text
+  - type: textarea
+    id: save-code
+    attributes:
+      label: Progress export code (only for save/progress bugs)
+      description: Click "Export Progress" and paste the code — it contains no personal data, just level/badges/commands.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ❓ Questions & help
+    url: https://github.com/renzorlive/vimmaster/discussions
+    about: Ask anything — setup, Vim itself, contribution ideas. No stupid questions.
+  - name: 🎉 Show & tell
+    url: https://github.com/renzorlive/vimmaster/discussions
+    about: Share your progress cards, streaks, and lesson ideas.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: 💡 Feature request
+description: Suggest an improvement or new capability
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check [docs/FeatureIdeas.md](../../blob/main/docs/FeatureIdeas.md) and the [roadmap](../../blob/main/ROADMAP.md) first — your idea may already be tracked (or explicitly rejected with reasons).
+        For **large changes** (architecture, content schema, dependencies, anything server-side), use the 📜 RFC template instead.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the learner/contributor pain, not just the solution.
+      placeholder: "As someone practicing daily, I lose motivation because…"
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Rough scope
+      options:
+        - Small (UI tweak, single lesson, copy change)
+        - Medium (new mode/screen, engine command)
+        - Large (should probably be an RFC)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/lesson_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/lesson_proposal.yml
@@ -1,0 +1,62 @@
+name: 📚 Lesson proposal
+description: Propose a new lesson or improve an existing one — no code required
+title: "content: "
+labels: ["content: lesson"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Lessons are the heart of VIMMaster — thank you! Read the short design guidelines in [docs/Lessons.md](../../blob/main/docs/Lessons.md) (one concept per lesson, win on outcomes).
+        You don't have to implement it: a good proposal here is a complete contribution, and someone else can wire it in.
+  - type: input
+    id: concept
+    attributes:
+      label: What does this lesson teach?
+      placeholder: "ciw — change inner word"
+    validations:
+      required: true
+  - type: input
+    id: track
+    attributes:
+      label: Where does it fit?
+      description: Which track / after which existing lesson?
+      placeholder: "Editing track, after 'Change Word (cw)'"
+  - type: textarea
+    id: buffer
+    attributes:
+      label: Starting buffer
+      description: The text the player sees. Keep lines under ~60 characters.
+      render: text
+      placeholder: |
+        The quick brown fux jumps over the lazy dog.
+        Fix the misspelled word using ciw.
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Win condition
+      description: What must be true to win? (final buffer text, cursor position, or a command that must be used)
+      placeholder: |
+        Line 1 becomes: "The quick brown fox jumps over the lazy dog."
+        Must use ciw (not x/r).
+    validations:
+      required: true
+  - type: textarea
+    id: instructions
+    attributes:
+      label: Player-facing instructions
+      placeholder: "Place the cursor anywhere on 'fux' and press ciw to change the whole word. Type 'fox', then Esc."
+    validations:
+      required: true
+  - type: input
+    id: par
+    attributes:
+      label: Optimal solution (key sequence)
+      description: The fewest keystrokes you can win with — proves it's solvable and sets par.
+      placeholder: "/fux <Enter> ciw fox <Esc>"
+  - type: textarea
+    id: hints
+    attributes:
+      label: Hints (optional)
+      description: 1–2 progressive hints for stuck players.

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,47 @@
+name: 📜 RFC (Request for Comments)
+description: Propose a significant change — architecture, content schema, save format, dependencies, anything server-side
+title: "RFC: "
+labels: ["rfc", "rfc: discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        RFC lifecycle: **Discussion → Accepted → Implemented** (or Rejected). Accepted RFCs are condensed into an [ADR](../../blob/main/docs/adr/README.md).
+        Read existing ADRs first — some directions are already decided (e.g. no backend by default, content as data) and reversing them needs to address the original reasoning.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What can't be done well today, and why does it matter for the mission?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Detailed proposal
+      description: Concrete enough that someone else could implement it. Include schema/API sketches where relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: At least one serious alternative, including "do nothing".
+    validations:
+      required: true
+  - type: textarea
+    id: tradeoffs
+    attributes:
+      label: Trade-offs, risks, migration
+      description: What gets worse? What breaks? How do existing users/saves/content migrate?
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I checked existing ADRs and the roadmap for conflicts
+          required: true
+        - label: This preserves "static site, no accounts, works offline" or explains why it must not
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!-- Thank you for contributing to VIMMaster! Small, single-concern PRs get reviewed fastest. -->
+
+## What does this PR do?
+
+<!-- One or two sentences. Link the issue: Fixes #123 -->
+
+## Type of change
+
+- [ ] 🐛 Bug fix
+- [ ] 📚 Content (lesson / challenge / achievement / translation)
+- [ ] ✨ Feature
+- [ ] 🧹 Refactor / tech debt
+- [ ] 📖 Docs
+
+## How was it verified?
+
+<!-- Until automated tests land, describe your manual verification (see the checklist in CONTRIBUTING.md). -->
+
+- [ ] Ran the game locally via a static server and exercised the affected flow end-to-end
+- [ ] Console is free of new errors
+- [ ] For lesson changes: played the lesson and **won** it
+- [ ] For engine changes: ran the manual test checklist (levels 1/2/5/6, one challenge, one cheat-mode practice, export/import)
+
+## Screenshots / recording
+
+<!-- Required for UI changes. Delete this section otherwise. -->
+
+## Notes for the reviewer
+
+<!-- Anything unusual: trade-offs, follow-ups, parts you're unsure about. Honesty speeds up review. -->
+
+---
+
+- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)
+- [ ] This PR does **one** thing
+- [ ] No content-specific logic added to engine code
+- [ ] Save-data format unchanged (or labeled `breaking-save` with a migration)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,90 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+* Being patient with beginners — VIMMaster exists for people learning something
+  new; "just read the manual" is not our culture
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Editor flame wars taken beyond good humor
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (the repository,
+issues, pull requests, discussions), and also applies when an individual is
+officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer via GitHub or the contact listed on the
+maintainer's profile ([@renzorlive](https://github.com/renzorlive)). All
+complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Correction** — a private, written warning, with clarity around the nature
+   of the violation. A public apology may be requested.
+2. **Warning** — a warning with consequences for continued behavior, including
+   temporary restriction from interaction.
+3. **Temporary Ban** — a temporary ban from any sort of interaction or public
+   communication with the community.
+4. **Permanent Ban** — a permanent ban from any sort of public interaction
+   within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing to VIMMaster
+
+**Learn Vim. Together.** Every lesson, translation, bug fix, and idea makes VIMMaster better for the next person trapped in Vim. Thank you for being here.
+
+Before diving in, skim [VISION.md](VISION.md) and the seven [project principles](PROJECT_PRINCIPLES.md) — every PR is evaluated against them — and [NON_GOALS.md](NON_GOALS.md) so you don't build something we've committed to never shipping.
+
+This guide gets you from zero to an open PR in **under 15 minutes**.
+
+## The 15-minute quickstart
+
+VIMMaster currently has **no build step**. You need a browser and any static file server — nothing else.
+
+```bash
+# 1. Fork on GitHub, then:
+git clone https://github.com/<you>/vimmaster.git
+cd vimmaster
+
+# 2. Serve it (pick whichever you have):
+npx serve .            # Node
+python -m http.server  # Python
+# …or use the Live Server extension in VS Code
+
+# 3. Open http://localhost:3000 (or :8000) — you're running VIMMaster.
+
+# 4. Create a branch, make your change, verify it in the browser:
+git checkout -b fix/level-5-typo
+
+# 5. Commit and open a PR:
+git commit -am "fix: correct typo in Delete Basics instructions"
+git push origin fix/level-5-typo
+```
+
+> ⚠️ Opening `index.html` directly from disk (`file://`) will **not** work — ES modules require a server. Use step 2.
+
+## Pick your path
+
+| I want to… | Start here | Code needed? |
+|---|---|---|
+| 🐛 Report a bug | [Open a bug report](../../issues/new?template=bug_report.yml) | No |
+| 📚 Add or improve a lesson | [docs/Lessons.md](docs/Lessons.md), then edit `js/levels.js` | Minimal (JSON-like objects) |
+| 💡 Propose a feature | [Open a feature request](../../issues/new?template=feature_request.yml) | No |
+| 🏗️ Propose a big change | [Open an RFC](../../issues/new?template=rfc.yml) — see "RFC process" below | No |
+| 🔧 Fix a bug / write code | Issues labeled [`good first issue`](../../issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) | Yes |
+| 🎨 Improve UI/design/themes | Issues labeled `ui` | Light |
+| 🌍 Translate | Coming with the content system ([docs/ContentSystem.md](docs/ContentSystem.md)) — watch `content: i18n` |
+
+## Adding a lesson (today's format)
+
+Lessons live in [`js/levels.js`](js/levels.js). Each is a plain object:
+
+```js
+{
+    name: "Delete Basics",
+    instructions: "Use dd to delete the full middle line.",
+    initialContent: ["Keep this line.", "Delete this entire line."],
+    targetContent: ["Keep this line."],          // win when buffer matches
+    setup: (gameState) => { gameState.cursor = { row: 0, col: 0 }; }
+}
+```
+
+Win-condition options (use exactly one): `target: {row, col}` (cursor position), `targetText: {line, text}` (one line matches), `targetContent: [lines]` (whole buffer matches), `exCommands: ["q"]` (an ex command was run).
+
+**Checklist for lesson PRs:**
+- [ ] One concept per lesson (see design guidelines in [docs/Lessons.md](docs/Lessons.md))
+- [ ] You played it and won it in the browser
+- [ ] Coordinates are 0-based and inside the buffer
+- [ ] Lines under ~60 characters
+
+A pure-JSON content system with automatic validation is coming ([docs/ContentSystem.md](docs/ContentSystem.md)) — lesson PRs will get even easier.
+
+## Code contributions
+
+### The change cycle
+
+All non-trivial work — from maintainers, agents, and contributors alike — follows the same cycle:
+
+1. **Analyze** the problem (issue or RFC).
+2. **Propose** the solution and its impact.
+3. **Get approval** (issue triage for small things, RFC acceptance for big ones).
+4. **Implement in small PRs**, each with: a single purpose, tests (once the test infra exists), updated docs, and a changelog entry.
+
+### Ground rules
+
+- **Small PRs, one concern each.** A bug fix and a refactor are two PRs.
+- **Never break existing functionality.** Play through the affected levels before and after your change.
+- **Match the surrounding style.** ES modules, no frameworks, no new dependencies without discussion.
+- **No new hardcoded content in engine code.** Engine changes that reference a specific lesson by name will be asked to use/extend the declarative approach instead.
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/): `fix:`, `feat:`, `content:`, `docs:`, `refactor:`, `chore:`.
+
+### Manual test checklist (until automated tests land)
+
+Before opening a PR that touches `js/`:
+
+1. Complete at least one level of each win-condition type (levels 1, 2, 5, 6).
+2. Open Challenge Mode, complete one task, let the timer expire once.
+3. Open Cheat Mode (`Ctrl+/`), run one practice lesson to completion.
+4. Export progress, clear it, import it back.
+5. Check the console for errors.
+
+### Where things live
+
+```
+index.html / profile.html   pages
+js/main.js                  entry point & DOM wiring
+js/game-state.js            all mutable state (getters/setters)
+js/vim-commands.js          keystroke → state (the Vim emulator)
+js/levels.js                lesson definitions
+js/event-handlers.js        win conditions, badges, challenges, updateUI
+js/ui-components.js         rendering
+docs/                       architecture, roadmap, content system, SEO…
+docs/adr/                   architecture decision records
+```
+
+Deep dives: [docs/Architecture.md](docs/Architecture.md) · [docs/GameEngine.md](docs/GameEngine.md) · [docs/TechnicalDebt.md](docs/TechnicalDebt.md)
+
+## RFC process (big changes)
+
+For anything that changes architecture, the content schema, save-data format, or adds a dependency:
+
+1. **RFC** — open an issue with the [RFC template](../../issues/new?template=rfc.yml) describing the problem, the proposal, and alternatives.
+2. **Discussion** — the community and maintainers weigh in; expect iteration.
+3. **Accepted** — a maintainer applies the `rfc: accepted` label and the decision is recorded as an ADR in [docs/adr/](docs/adr/).
+4. **Implemented** — PRs reference the RFC; the ADR is updated to `Implemented`.
+
+Skipping the RFC for a large PR usually means rework — save yourself the time.
+
+## Architecture Decision Records
+
+Significant technical decisions are recorded in [docs/adr/](docs/adr/) (why, alternatives, trade-offs). Read them before proposing to reverse one — and feel free to propose reversing one via RFC when circumstances change.
+
+## Review expectations
+
+- Maintainers aim to respond to PRs within a few days; `good first issue` PRs get priority.
+- Reviews are about the code, never the person — see our [Code of Conduct](CODE_OF_CONDUCT.md).
+- CI (build/lint/tests) is being introduced in Phase 0.5 of the [roadmap](ROADMAP.md); until then, the manual checklist above is the bar.
+
+## Recognition
+
+Contributors are credited in release notes, and once the content system lands, lesson files carry an `author` field rendered **in-game** ("Lesson by @you"). Your name ships with the thing you made.
+
+## Questions?
+
+Open a [Discussion](../../discussions) or an issue — there are no stupid questions, especially about Vim. 🙂

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,29 @@
+# Decisions
+
+The major standing decisions, at a glance. Full reasoning (context, alternatives, trade-offs) lives in [docs/adr/](docs/adr/README.md); commitments about what we won't build live in [NON_GOALS.md](NON_GOALS.md).
+
+## Decided ✔
+
+| Decision | Detail |
+|---|---|
+| ✔ **No backend** | Static site; optional extras (leaderboards, opt-in analytics) must degrade to nothing — [ADR-0004](docs/adr/0004-no-backend-by-default.md) |
+| ✔ **No account required** | localStorage + export codes are the persistence model — [ADR-0004](docs/adr/0004-no-backend-by-default.md) |
+| ✔ **Offline first** | Full functionality after first load; PWA planned — [PROJECT_PRINCIPLES.md](PROJECT_PRINCIPLES.md) #2 |
+| ✔ **Lessons are JSON** | All content is data; engine contains zero content-specific code — [ADR-0003](docs/adr/0003-content-as-data.md) |
+| ✔ **Every lesson is CI-proven solvable** | Content ships a `solution` replayed by CI — [docs/ContentSystem.md](docs/ContentSystem.md) |
+| ✔ **No AI dependency at runtime** | Deterministic, human-authored content — [NON_GOALS.md](NON_GOALS.md) |
+| ✔ **Static deployment** | GitHub Pages / Cloudflare; output is plain files |
+| ✔ **SEO pages generated from content** | `/commands/*`, `/tutorials/*` built from the same JSON — [docs/SEO.md](docs/SEO.md) |
+| ✔ **No ads, no trackers, no paywalls** | [NON_GOALS.md](NON_GOALS.md) |
+| ✔ **Decisions are recorded** | RFC → ADR process — [ADR-0001](docs/adr/0001-record-architecture-decisions.md) |
+| ✔ **Outcome-based validation** | Lessons validate the edit achieved, not the exact keystrokes |
+
+## Proposed (pending RFC) ◌
+
+| Decision | Detail |
+|---|---|
+| ◌ **Vite + TypeScript build; Preact UI shell; pure-TS Vim core** | [ADR-0002](docs/adr/0002-build-tooling-and-ui-framework.md) — confirm via RFC before tooling PRs merge |
+
+## How to change any of these
+
+Open an [RFC](CONTRIBUTING.md#rfc-process-big-changes) that engages with the original ADR's reasoning. "I disagree" is a comment; "circumstances changed, here's the evidence and the migration" is an RFC.

--- a/NON_GOALS.md
+++ b/NON_GOALS.md
@@ -1,0 +1,29 @@
+# Non-Goals
+
+What VIMMaster deliberately is **not** and will **not** become. These are commitments, not current limitations — proposals that cross them will be declined with a link to this file. To challenge one, open an [RFC](CONTRIBUTING.md#rfc-process-big-changes) that addresses the reasoning in the linked ADRs.
+
+## We are NOT trying to:
+
+❌ **Replace Neovim** — or Vim, or your editor. VIMMaster is a gym, not a workplace. We emulate the teachable subset *correctly*, nothing more.
+
+❌ **Become a full IDE** — no file trees, no LSP, no terminals. One buffer, one skill, focused practice.
+
+❌ **Simulate every Vim plugin or option** — no `.vimrc`, no plugin ecosystem, no distro debates. Core Vim fluency transfers everywhere; configs don't.
+
+❌ **Require registration** — no accounts, no email capture, no "sign in to save progress". ([ADR-0004](docs/adr/0004-no-backend-by-default.md))
+
+❌ **Require internet** — after first load, everything works offline. Networked extras must degrade to nothing.
+
+❌ **Become a gamified addiction app** — no lives, no timers pressuring you to pay, no guilt notifications, no infinite-scroll dopamine. Streaks and stars celebrate mastery; they never punish absence.
+
+❌ **Lock content behind paywalls** — every lesson, every track, every feature: free, for everyone, forever. No "pro tier".
+
+❌ **Ship ads or trackers** — no ad networks, no Google Analytics, no third-party pixels. Trust and speed are the product.
+
+❌ **Depend on AI services at runtime** — lessons are deterministic, human-authored, and CI-verified. The app never calls an LLM to function.
+
+❌ **Adopt a backend as the default architecture** — static site first; any server-side extra is optional, isolated, and the app must work identically without it. ([ADR-0004](docs/adr/0004-no-backend-by-default.md))
+
+---
+
+*Why written down?* Because every one of these will be suggested — usually with good intentions and a plausible benefit. Non-goals turn those recurring debates into a link, and keep the project's promise simple: **open the page, learn Vim, no strings.**

--- a/PROJECT_PRINCIPLES.md
+++ b/PROJECT_PRINCIPLES.md
@@ -1,0 +1,45 @@
+# Project Principles
+
+Seven principles. Every PR, feature, and RFC is evaluated against them. When two conflict, the one higher on the list wins.
+
+---
+
+## 1. Learning first
+
+VIMMaster exists to teach. Never sacrifice clarity for realism, cleverness, or completeness. If a lesson confuses one tester, the lesson is wrong — not the tester.
+
+---
+
+## 2. Offline first
+
+The core experience works with no server and no connection after first load. Any networked feature must degrade to nothing, silently.
+
+---
+
+## 3. No login required
+
+No accounts, ever, for anything. Your progress is yours, on your device, exportable as a code.
+
+---
+
+## 4. Content over code
+
+Lessons, challenges, achievements, and translations are data. If adding content requires editing application code, the architecture is broken — fix the architecture, not the content.
+
+---
+
+## 5. Accessibility first
+
+Keyboard-navigable, screen-reader-considerate, reduced-motion-respecting. A learning tool that excludes learners has failed at its only job.
+
+---
+
+## 6. Performance is a feature
+
+The page loads in the time it takes to lose a beginner's courage. Every dependency, image, and script must justify its bytes.
+
+---
+
+## 7. Community before complexity
+
+Prefer the solution a new contributor can understand. A simpler design that ten people can maintain beats a brilliant one that only its author can.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,0 +1,36 @@
+# Project Status
+
+> One page, always current: where the project is *right now*. Updated with every milestone; if this file contradicts anything else, this file is stale — please open an issue.
+
+**Last updated:** 2026-07-09
+
+| | |
+|---|---|
+| **Current version** | pre-1.0 (unversioned; semver starts with the first tagged release in Phase 0.5) |
+| **Current phase** | ✅ Phase 0.5 docs/infra complete → ▶️ **entering Phase 0 — Stabilize** ([ROADMAP.md](ROADMAP.md)) |
+| **Current sprint** | Critical bug fixes, one PR each |
+| **Current focus** | **TD-1: the save-corruption bug** — finishing the final level invalidates and deletes the player's saved progress ([docs/TechnicalDebt.md](docs/TechnicalDebt.md)) |
+| **Next milestone** | *Stable v0.1*: all Phase 0 boxes checked — 5 bug fixes, debug logging stripped, SEO meta tags |
+| **Release target** | v1.0 after Phases 0–3 (engine rewrite + content system + platform pages) — no date commitment; quality gates over deadlines |
+
+## Known issues (top of the list)
+
+| # | Issue | Severity |
+|---|---|---|
+| TD-1 | Progress save rejected & **deleted** after reaching the final level (off-by-one, 15 vs 16 levels) | 🔴 |
+| TD-2 | Per-level cursor start positions silently ignored (`setup()` result discarded) | 🔴 |
+| TD-3 | Auto-save on level completion never fires (dead `window` hook) | 🔴 |
+| TD-6 | Duplicate, divergent challenge scoring implementations | 🔴 |
+| TD-11 | ~150 debug `console.log`s ship to production, some per-keystroke | 🟡 |
+
+Full register with file/line references: [docs/TechnicalDebt.md](docs/TechnicalDebt.md).
+
+## How work happens right now
+
+Every change follows the cycle: **analyze → propose (with impact) → approval → implement** in small PRs — one purpose each, with tests (once the test infra lands in Phase 0.5 tooling), updated docs, and a changelog entry. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Recently completed
+
+- ✅ Architecture analysis + full `/docs` suite (Architecture, GameEngine, ContentSystem, Lessons, SEO, TechnicalDebt, FeatureIdeas, ContributingVision)
+- ✅ Contributor infrastructure: CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, issue/PR/RFC templates
+- ✅ Governance: ROADMAP, VISION, PROJECT_PRINCIPLES, NON_GOALS, DECISIONS, ADR system with 4 founding records

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
+<p align="center">
+  <img src="images/banner.svg" alt="VIM Master — Learn Vim. Together. The open-source platform for mastering Vim." width="100%">
+</p>
+
 # VIM Master
 
-VIM Master -- in-browser game that teaches core Vim motions and editing commands through short, focused levels. 
+**Learn Vim. Together.** — *The open-source platform for mastering Vim.*
+
+An in-browser game that teaches core Vim motions and editing commands through short, focused levels — free, no signup, no backend, works offline. And more than a game: VIM Master is growing into a community-driven platform where lessons, challenges, achievements, and translations are contributed as data, without touching application code.
+
+🧭 [Vision](VISION.md) · 📍 [Roadmap](ROADMAP.md) · 📊 [Status](PROJECT_STATUS.md) · 🤝 [Contributing (PR in 15 minutes)](CONTRIBUTING.md) · ⚖️ [Principles](PROJECT_PRINCIPLES.md) · 🚫 [Non-goals](NON_GOALS.md) · 📜 [Decisions](DECISIONS.md)
 
 ## Try the Online Demo
 [![Demo Online](https://img.shields.io/badge/demo-online-brightgreen?logo=github&style=for-the-badge)](https://renzorlive.github.io/vimmaster/)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,151 @@
+# VIMMaster Roadmap
+
+> **Learn Vim. Together.** — *The open-source platform for mastering Vim.*
+> Not just a game — a platform: interactive lessons, generated documentation, a community that contributes content without writing code, and a page for every Vim command a person might search for. Why we're building it: [VISION.md](VISION.md).
+
+Phased so that **every phase ships a working, deployed site**, and every checkbox is a small, reviewable PR. Big decisions go through the [RFC process](CONTRIBUTING.md#rfc-process-big-changes) and are recorded as [ADRs](docs/adr/).
+
+```
+Phase 0   Stabilize
+Phase 0.5 Developer Experience   ← contributor infra ready BEFORE growth
+Phase 1   Architecture
+Phase 2   Content
+Phase 3   Platform
+Phase 4   Community
+Phase 5   Release (1.0)
+```
+
+---
+
+## Phase 0 — Stabilize *(days)*
+
+Bug fixes and free wins on the current codebase. No structural change. Details: [docs/TechnicalDebt.md](docs/TechnicalDebt.md).
+
+- [ ] Fix progress-save off-by-one that deletes saves after the final level (TD-1)
+- [ ] Fix `level.setup()` being discarded — restore per-level start positions (TD-2)
+- [ ] Fix dead auto-save-on-completion hook (TD-3)
+- [ ] Remove duplicated/dead challenge scoring (TD-6)
+- [ ] Strip all shipped `🔍 DEBUG` console logging (TD-11)
+- [ ] Meta description, Open Graph/Twitter cards, favicon link, canonical, robots.txt ([docs/SEO.md](docs/SEO.md) Phase 0)
+
+**Exit:** finish all 16 levels, reload, keep progress; console clean; shared links render cards.
+
+## Phase 0.5 — Developer Experience *(days–1 week)*
+
+Infrastructure for contributors **before** the project attracts attention. A first-time contributor must go from fork to open PR in under 15 minutes.
+
+- [x] `CONTRIBUTING.md` — persona-based, 15-minute quickstart
+- [x] `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1
+- [x] `ROADMAP.md` (this file) — canonical plan
+- [x] `docs/adr/` — ADR process + founding decisions recorded
+- [x] GitHub issue templates (bug, feature, lesson proposal, RFC) + PR template
+- [x] `SECURITY.md`
+- [ ] GitHub labels created per [docs/ContributingVision.md](docs/ContributingVision.md)
+- [ ] GitHub Discussions enabled (Q&A, Ideas, Show & Tell)
+- [ ] Seed 5–10 well-scoped `good first issue`s from Phase 0 / TechnicalDebt items
+- [ ] `package.json` + Vite (output identical site) — RFC/ADR-0002
+- [ ] ESLint + Prettier + `.editorconfig`
+- [ ] Vitest + first tests (progress-system, pure helpers)
+- [ ] GitHub Actions: build + lint + test on PR; deploy on `main`
+- [ ] Replace Tailwind CDN with build-time Tailwind (TD-10)
+
+**Exit:** CI is a required check; a stranger can clone, run, change, and PR without asking anything.
+
+## Phase 1 — Architecture *(3–4 weeks)*
+
+The pure Vim core. Details: [docs/GameEngine.md](docs/GameEngine.md), [docs/Architecture.md](docs/Architecture.md).
+
+- [ ] TypeScript adoption (`allowJs`, migrate module by module)
+- [ ] `src/core/vim`: `dispatch(state, key) → state` reducer — zero DOM, zero globals
+- [ ] Real command grammar (count/operator/motion state machine) replacing string-suffix parsing
+- [ ] Engine **event stream** (motions, deletes, searches, undo/redo…) powering validation, scoring, achievements, analytics
+- [ ] Vim-fidelity fixes with tests: word motions incl. punctuation, `cw` semantics, undo consistency, insert-mode Enter
+- [ ] Table-driven test suite (>90% coverage of the core)
+- [ ] UI shell decision executed per ADR-0002 (Preact/TSX components, feature by feature)
+
+**Exit:** every taught command has tests; adding `f/t`, text objects, or visual mode is a grammar extension.
+
+## Phase 2 — Content *(2–3 weeks, parallelizable with Phase 1)*
+
+Content becomes data. Details: [docs/ContentSystem.md](docs/ContentSystem.md).
+
+- [ ] Content schemas (zod) + loader + `npm run validate:content`
+- [ ] Migrate 16 levels → `/content/lessons` (tracks: survival, movement, editing, search)
+- [ ] Declarative validators replace level-name checks and per-level flags in the engine
+- [ ] Migrate challenges and achievements to content files (kills 3 duplicated badge maps)
+- [ ] Cheat sheet reads `/content/commands`; practice buttons launch real lessons; delete duplicated `vimLessons`
+- [ ] **Solution replay in CI** — every merged lesson is provably solvable
+- [ ] **Contributor playground** — drag-and-drop a `lesson.json` into the running app and play it instantly, no PR needed
+- [ ] "Add a lesson in 5 minutes" guide + lesson PR template refresh
+- [ ] New tracks: text objects, visual mode (the biggest learning-value gaps)
+
+**Exit:** adding a lesson = adding one JSON file; engine contains zero content-specific code; you can test a lesson locally without touching git.
+
+## Phase 3 — Platform *(4–6 weeks)*
+
+From game to destination.
+
+**Landing page** (index becomes a real front door; the game moves to `/play` or stays above the fold — RFC):
+- [ ] Hero ("The Open Source Home for Learning Vim") · Why Vim? · live demo · learning path · features · community · contributors · Start Learning CTA
+- [ ] Showcase strip: contributor avatars, latest lessons, recent releases, GitHub stars — generated at build time
+
+**Brand:**
+- [ ] Logo + favicon set (SVG), color palette, mascot exploration, social/OG card imagery — `brand/` directory with usage guide
+
+**Docs website:**
+- [ ] Docs site (VitePress or similar) from `/docs`: Guide · Lessons · Commands · FAQ · Contributing · Architecture · API · Roadmap
+- [ ] Command reference pages generated from `/content/commands`
+
+**Playground:**
+- [ ] **Scratch buffer** — free-play page with the full emulator + live command log; no lesson, no goal ("Vim playground online")
+
+**SEO content engine** ([docs/SEO.md](docs/SEO.md) Phase 2):
+- [ ] Static page per command (`/commands/dd`, `/commands/gg`, `/commands/ciw`…) generated from content JSON, each with prose + playable embed
+- [ ] Tutorial pages (`/tutorials/text-objects`, `/tutorials/macros`, `/tutorials/registers`) + `/reference`
+- [ ] Sitemap generation, JSON-LD `LearningResource`
+
+**Analytics (privacy-first, own events — no Google Analytics):**
+- [ ] Event vocabulary: lesson started/finished, command failed, retries, drop-off point, hints used
+- [ ] Local-first: aggregate in localStorage; opt-in anonymous beacon to a Cloudflare Worker (wrangler.toml already exists) — RFC + ADR required
+- [ ] "Most failed lesson" report feeding content improvements
+
+**App quality:**
+- [ ] PWA: manifest + service worker (offline play)
+- [ ] Accessibility pass: focus traps, ARIA, reduced-motion, keyboard-navigable menus
+- [ ] Keystroke par + stars per lesson (Codewars-style efficiency scoring)
+- [ ] Skill-tree lesson browser replacing the numbered button strip
+
+**Exit:** vimmaster is a site people land on from search, not just a toy people are linked to.
+
+## Phase 4 — Community *(ongoing)*
+
+- [ ] RFC process actively used; ADR log grows
+- [ ] i18n: UI catalog + lesson overrides; first community translations
+- [ ] Daily challenge (deterministic, client-side) + share cards
+- [ ] Streaks & practice reminders (client-side)
+- [ ] Golf mode / race-your-ghost (see [docs/FeatureIdeas.md](docs/FeatureIdeas.md))
+- [ ] Optional anonymous leaderboards (Cloudflare Worker + KV) — RFC; keep the core playable fully offline
+- [ ] Embeddable lesson widget for blogs/docs (every embed is a backlink)
+- [ ] In-game lesson attribution ("Lesson by @name") + all-contributors bot
+- [ ] Monthly "state of VIMMaster" discussion post
+
+## Phase 5 — Release *(when Phases 0–3 are done)*
+
+- [ ] Custom domain, canonical consolidation, redirects
+- [ ] Brand polish across game, landing, docs, share cards
+- [ ] v1.0 tag + changelog + launch posts (r/vim, r/neovim, Hacker News — hook: text objects + golf mode + playground)
+- [ ] Submit to awesome-vim lists, Vim/Neovim wikis, alternativeto (Vim Adventures alternative)
+- [ ] Post-launch: watch analytics drop-off reports → content fixes
+
+---
+
+## Non-goals (for focus)
+
+- Accounts/logins/user databases — export codes + localStorage remain the model
+- Full Vim emulation (VimScript, plugins, splits)
+- Ads or monetization features
+- Heavy frameworks or SSR — static and instant, forever
+
+## Success metric (2-year horizon)
+
+Not feature count. **Dozens of active contributors adding content without maintainer bottlenecks, on a codebase that stays easy to maintain.** Every phase above is judged against that.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+VIMMaster is a static site with no accounts, no backend, and no personal data collection — but security still matters: we render user-importable data (progress codes), build HTML from content, and ship third-party dependencies.
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for security problems. Instead:
+
+- Use GitHub's **[private vulnerability reporting](../../security/advisories/new)** ("Report a vulnerability" on the Security tab), or
+- Contact the maintainer directly via their GitHub profile ([@renzorlive](https://github.com/renzorlive)).
+
+You can expect an acknowledgment within a few days. Please include reproduction steps and, if relevant, a crafted progress code or content file demonstrating the issue.
+
+## Scope — things we care about
+
+- XSS via imported progress codes, lesson/challenge content, or share-card data
+- Malicious `lesson.json` files once the contributor playground ships
+- Dependency vulnerabilities (once `package.json` exists — Dependabot will be enabled)
+- Anything that could compromise a visitor's browser or localStorage beyond VIMMaster's own keys
+
+## Out of scope
+
+- Progress-code "cheating" (editing your own local save is a feature, not a vulnerability)
+- Issues requiring a compromised browser or machine
+
+Thank you for keeping learners safe. 🔒

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,73 @@
+# Vision
+
+> **Learn Vim. Together.**
+> *The open-source platform for mastering Vim.*
+
+This document explains **why VIMMaster exists**. The [README](README.md) tells you what it is, the [ROADMAP](ROADMAP.md) tells you what's next — this tells you what we're actually building, and why it's worth your time.
+
+## Why VIMMaster exists
+
+Vim is one of the highest-leverage skills a person who types for a living can learn — and one of the worst-taught. The learning curve is a wall: cryptic keys, modal editing that fights every instinct, and documentation written for people who already understand it. Most people bounce off within an hour. The famous joke — *"how do I exit Vim?"* is one of the most-searched programming questions ever — is funny precisely because the wall is real.
+
+Meanwhile, the tools that *do* teach well — Duolingo, TypeRacer, Codewars — proved something important: **short feedback loops, real practice, and a little play beat manuals every time.**
+
+VIMMaster exists to put those two facts together: the most valuable editing skill, taught the way skills are actually learned — interactively, incrementally, in the browser, in seconds from clicking a link.
+
+## Why another Vim project?
+
+There are Vim tutorials (passive), `vimtutor` (great, but you must already be *in* Vim), Vim Adventures (wonderful, but paid and closed), and countless cheat sheets (reference, not practice). What doesn't exist is:
+
+**A free, open-source, community-owned place where anyone can learn Vim by doing — and where anyone can teach by contributing a lesson without writing code.**
+
+That second half is the actual gap. Every existing option is one author's curriculum. VIMMaster's curriculum is a folder of JSON files with a CI check that proves every lesson is solvable. That's a structurally different thing: it compounds.
+
+## Why open source?
+
+- **Teaching material improves with many eyes.** A confusing lesson gets fixed by the first confused learner who becomes a contributor.
+- **Vim's culture is open source.** A closed Vim-learning product is dissonant; the community this serves is the community that can build it.
+- **Trust.** No accounts, no tracking, no paywall — claims only verifiable because the code is public.
+- **Longevity.** Personal projects die with their maintainer's attention. Platforms with contributors, recorded decisions, and clear processes survive.
+
+## Who is it for?
+
+- **Developers who keep meaning to learn Vim** and need the wall lowered to a staircase.
+- **Vim-curious students and writers** who want to try before configuring anything.
+- **Intermediate Vim users** with plateaued habits (arrow keys, no text objects) who need targeted drills.
+- **Teachers and mentors** who want a link to send instead of a lecture.
+- **Contributors** who enjoy teaching: the lesson format is the product.
+
+## Who is NOT the target audience?
+
+- **Vim power users seeking emulation perfection.** We teach the 20% that gives 80% of the power; Neovim is right there.
+- **People choosing an editor for production work today.** VIMMaster is a gym, not an IDE.
+- **Plugin/config enthusiasts.** `.vimrc` golf, plugin managers, and distro debates are out of scope — gloriously so.
+
+## What will never be added?
+
+See [NON_GOALS.md](NON_GOALS.md) — the short version: no accounts, no required internet after first load, no paywalls, no dark-pattern gamification, no full-Vim emulation, no ads. These are commitments, not current gaps.
+
+## What makes VIMMaster different?
+
+1. **Zero to practicing in five seconds.** A URL, not an install.
+2. **Outcome validation, not keystroke mimicry.** You win by *achieving the edit*, any legal way — like real editing.
+3. **Content is data.** Lessons, challenges, achievements, and translations are JSON. Contributors teach without touching code, and CI replays every lesson's solution before merge — an unbeatable lesson cannot ship.
+4. **Privacy as architecture, not policy.** Static site, localStorage, export codes. There is no server to leak anything.
+5. **The same content powers everything** — the game, the cheat sheet, the docs site, and a generated SEO page for every command, so the project grows more findable as it grows more useful.
+
+## Long-term vision (5 years)
+
+When someone anywhere in the world decides to learn Vim, VIMMaster is the obvious first stop — and when they search "vim ciw" a year later, they land on our generated reference page with a playable example.
+
+Concretely, by then:
+
+- **Hundreds of lessons** across tracks from "exit Vim" to registers, macros, and text-object fluency — most written by the community, each attributed in-game to its author.
+- **A living curriculum in many languages**, maintained by translators who never opened `src/`.
+- **A place people return to**: daily challenges, keystroke golf, racing your own ghost — mastery mechanics, not engagement traps.
+- **Dozens of active contributors** and a maintainer team, with RFCs, ADRs, and CI making the project easy to steward and hard to break.
+- **Still: no login, no tracking, free, instant, open.** If we scale by betraying any of those, we failed.
+
+The measure of success is not stars or traffic. It's this sentence being commonly true: *"I learned Vim on VIMMaster — and I fixed a lesson while I was there."*
+
+## Core principles
+
+The seven principles that every PR is weighed against live in [PROJECT_PRINCIPLES.md](PROJECT_PRINCIPLES.md). Major standing decisions are listed in [DECISIONS.md](DECISIONS.md) with their full reasoning in [docs/adr/](docs/adr/).

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,166 @@
+# VIMMaster Architecture
+
+This document describes the architecture as it exists today, the target architecture, and the migration path between them.
+
+## 1. Current State (as of 2026-07)
+
+### Stack
+
+| Layer | Technology |
+|---|---|
+| Markup | Two static pages: `index.html` (game), `profile.html` (profile/sharing) |
+| Styling | Tailwind via CDN script + `css/main.css` |
+| Logic | 11 vanilla-JS ES modules under `js/`, loaded with `<script type="module">` |
+| Build | None — files are served as-is |
+| Deploy | GitHub Pages + Cloudflare (`wrangler.toml`) |
+| Persistence | `localStorage` + Base64 export/import codes |
+| Tests / CI / Lint | None |
+
+### Module map
+
+```
+index.html
+└── js/main.js            entry point: init, DOM wiring, auto-save loop
+    ├── game-state.js     module-singleton state (~30 vars, ~70 getters/setters)
+    ├── levels.js         16 hardcoded level definitions + loadLevel()
+    ├── vim-commands.js   keydown → state mutation (NORMAL/INSERT/SEARCH handlers)
+    ├── event-handlers.js checkWinCondition, badges, challenge orchestration, updateUI
+    ├── ui-components.js  DOM rendering (editor, status bar, modals, badges)
+    ├── challenges.js     3 hardcoded timed challenges
+    ├── cheat-mode.js     command reference panel + 16 hardcoded practice lessons
+    └── progress-system.js localStorage save/load, export/import codes
+
+profile.html
+└── js/profile-page.js
+    └── sharing-system.js  canvas achievement cards, social share links
+```
+
+### How the pieces work
+
+**State management.** `game-state.js` holds all mutable state in private module variables and exposes them exclusively through getter/setter functions. Getters return defensive copies. There is no store, no events, no subscriptions — modules call setters and then someone calls `updateUI()` to re-render everything.
+
+**The editor.** There is no real text-editing widget. A visually-hidden `<textarea>` (`#vim-editor-input`) captures keyboard focus; its `keydown` handler dispatches to `handleNormalMode` / `handleInsertMode` / `handleSearchMode` in `vim-commands.js`. The visible editor (`#vim-editor-display`) is rebuilt from scratch (`innerHTML`) after every keystroke by `renderEditor()`.
+
+**Command parsing.** Single keys are handled by `if (key === ...)` chains. Multi-key commands (`dd`, `dw`, `gg`, `cw`, `yy`) are detected by appending each key to a `commandHistory` string and checking `endsWith('dd')` etc. Counts (`3w`) accumulate in a `countBuffer` string. Ex commands (`:q`) are parsed from `commandHistory` on Enter.
+
+**Lessons/levels.** `levels.js` exports a hardcoded array. Each level has `name`, `instructions`, `initialContent`, an optional `setup()`, and one of four win-condition shapes:
+
+- `target: {row, col}` — cursor position
+- `targetText: {line, text}` — one line equals a string
+- `targetContent: [lines]` — whole buffer equals (whitespace-tolerant)
+- `exCommands: [...]` — an ex command was executed
+
+Win checking lives in `checkWinCondition()` (event-handlers.js). Search levels and the undo/redo level additionally have behavior requirements enforced by **level-name string matching** and dedicated global flags (`level12Undo`, `usedSearchInLevel`, `navCountSinceSearch`).
+
+**Routing.** None. Two pages, plain links.
+
+**Rendering flow per keystroke:**
+
+```
+keydown → handleXxxMode() mutates state
+        → updateUI() → renderEditor / updateStatusBar / updateInstructions
+                        / level buttons / badges (full re-render)
+        → checkWinCondition() or checkPracticeCompletion()
+```
+
+### Known defects (see TechnicalDebt.md for the full list)
+
+1. `progress-system.js` validates `currentLevel <= 14` and hardcodes `totalLevels: 15`, but there are 16 levels — saved progress from the final level is rejected **and deleted** on reload.
+2. `loadLevel()` passes a *copy* of cursor state to `level.setup()`, so per-level start positions are silently ignored; every level starts at `{0,0}`.
+3. `setupAutoSave()` wraps `window.checkWinCondition`, which is never set on `window` — the on-completion auto-save never fires.
+4. `challenges.js#checkChallengeTask/endChallenge` are dead code; scoring was re-implemented (with different values) in `checkWinCondition`.
+5. The cursor-bounds clamp at the end of `handleNormalMode` reads a stale cursor snapshot.
+
+## 2. Target Architecture
+
+The long-term vision: **a data-driven learning platform** where the engine knows nothing about specific lessons, and all content (lessons, challenges, achievements, command reference, translations) lives in declarative files contributors can edit without touching code.
+
+### Guiding principles
+
+- **Engine/content separation.** The Vim emulator and game engine consume content descriptors; nothing in engine code references a specific lesson.
+- **Pure core, thin shell.** The Vim emulator is a pure function: `(EditorState, KeyEvent) → EditorState`. All DOM work lives at the edge. This is what makes the core unit-testable.
+- **Stay fast.** Static-first delivery, no server required to play, offline-capable (PWA). Any framework choice must keep first-load small.
+- **Progressive migration.** Never a big-bang rewrite; each step ships a working game.
+
+### Target layout (feature-based)
+
+```
+/content                    ← contributor-facing, no code
+  /lessons/<track>/<id>.json
+  /challenges/<id>.json
+  /achievements/achievements.json
+  /commands/commands.json   ← cheat-sheet + command metadata
+  /i18n/<locale>.json
+/src
+  /core                     ← pure TypeScript, zero DOM
+    /vim                    editor state, motions, operators, registers, modes
+    /engine                 lesson runner, validators, scoring, achievements
+    /content               schema types, loaders, zod validation
+  /features
+    /lesson-player          UI for playing a lesson
+    /challenge-mode
+    /cheat-sheet
+    /profile
+    /progress               persistence, export/import
+  /ui                       shared components (editor view, modal, toast…)
+  /app                      entry, routing, layout
+/tests
+  /core                     unit tests (vitest)
+  /content                  schema validation of all content files
+  /e2e                      playwright smoke tests
+/docs
+/.github                    templates, workflows, labels
+```
+
+### Technology decisions (compared)
+
+**Build tooling — Vite + TypeScript.** Recommended unconditionally. It preserves the instant-static deployment model (output is still plain static files), adds type safety, dead-code elimination, minification, and removes the Tailwind CDN script. Cost: contributors need `npm install`. This is the single highest-leverage change.
+
+**UI framework — three options considered:**
+
+| Option | Pros | Cons |
+|---|---|---|
+| Stay vanilla + TS | zero deps, smallest bundle | hand-rolled rendering/diffing grows unmaintainable as UI grows (profile, settings, i18n, lesson browser) |
+| **Preact + TS (recommended)** | React model & ecosystem, ~4 KB, drop-in `react` alias, easy contributor onboarding | slightly smaller ecosystem than React proper |
+| React 19 | largest contributor familiarity | ~45 KB baseline for a game whose core is a `<pre>` block |
+
+Recommendation: **Preact with the React compat alias** — contributors write standard React/TSX, the bundle stays tiny, and a later switch to React is a one-line alias change if ever needed. The Vim core itself stays framework-free (pure TS), so this choice only affects the shell.
+
+**Styling — Tailwind as a build-time dependency** (replaces the CDN script), keeping current visual design.
+
+**State — keep it simple.** The pure core owns editor state. App-level state (progress, settings) fits in one small store (zustand or a hand-rolled `useSyncExternalStore` store). No Redux.
+
+### The pure Vim core (see GameEngine.md for detail)
+
+```ts
+interface EditorState {
+  buffer: string[];
+  cursor: { row: number; col: number };
+  mode: 'normal' | 'insert' | 'visual' | 'command' | 'search';
+  pending: PendingInput;        // operator, count, register…
+  registers: Record<string, Register>;
+  undo: UndoHistory;
+  search: SearchState;
+  lastEvent: EngineEvent | null; // what just happened, for validators
+}
+
+function dispatch(state: EditorState, key: KeyInput): EditorState;
+```
+
+Deterministic, side-effect-free, snapshot-testable. Lesson validators consume `EditorState` + an event log instead of poking at global flags.
+
+## 3. Migration path (safe, incremental)
+
+Each phase leaves the game fully working. Details and sequencing in Roadmap.md.
+
+1. **Stabilize** — fix known bugs, strip debug logging, add the missing meta/SEO tags. Pure wins, no structural change.
+2. **Tooling** — add `package.json`, Vite, ESLint/Prettier, vitest; move `js/` under `src/` unchanged; CI runs build + lint + tests. Output identical site.
+3. **Extract content** — move levels/challenges/achievements/commands into `/content` JSON with a schema + loader; delete the duplicated cheat-mode lesson copies; remove level-name checks from the engine by introducing declarative validator types.
+4. **Type & purify the core** — convert `vim-commands.js`/`game-state.js` into the pure TS core with a proper key/operator/motion parser; grow unit-test coverage here first.
+5. **Shell migration** — rebuild UI surfaces as Preact components feature by feature (editor view → lesson player → cheat sheet → profile).
+6. **Platform features** — lesson tracks, i18n, PWA/offline, leaderboards-without-backend, etc. (Roadmap.md).
+
+## 4. Non-goals
+
+- No backend/accounts in the foreseeable future. localStorage + export codes preserve the privacy-first model.
+- No attempt at full Vim fidelity (that's Neovim's job). We emulate the subset lessons teach, but that subset must behave *correctly*.

--- a/docs/ContentSystem.md
+++ b/docs/ContentSystem.md
@@ -1,0 +1,198 @@
+# Content System
+
+Design for the data-driven content layer: lessons, challenges, achievements, tutorials, command reference, and translations — all editable without touching application code.
+
+## Goals
+
+- A first-time contributor can add a lesson by creating **one JSON file** and opening a PR.
+- CI validates every content file against a schema and replays its solution through the engine — a green check means the lesson works.
+- The engine has **zero** knowledge of any specific piece of content (no level-name checks, no per-level flags).
+- The same schema powers the game, the cheat-sheet practice mode, and future features (daily challenge, placement test).
+
+## Directory layout
+
+```
+/content
+  /lessons
+    /basics            ← track = directory
+      track.json       ← track metadata + lesson ordering
+      exiting-vim.json
+      hjkl-movement.json
+      …
+    /editing
+    /search
+  /challenges
+    speed-navigation.json
+    quick-deletion.json
+  /achievements
+    achievements.json
+  /commands
+    commands.json      ← command reference (cheat sheet) + metadata
+  /i18n
+    en.json            ← UI strings
+    de.json
+    /lessons           ← per-locale lesson overrides (optional)
+```
+
+## Lesson schema
+
+```jsonc
+// content/lessons/basics/hjkl-movement.json
+{
+  "id": "hjkl-movement",            // stable, kebab-case, unique
+  "version": 1,
+  "title": "Basic Movement",
+  "instructions": "Use h, j, k, l to move the cursor. Reach the target character '$'.",
+  "difficulty": "beginner",          // beginner | intermediate | advanced
+  "commands": ["h", "j", "k", "l"],  // links to /content/commands entries
+  "buffer": [
+    "Move with h(left), j(down), k(up), l(right).",
+    "Your cursor starts here.",
+    "",
+    "Once you are comfortable, move to the '$'."
+  ],
+  "start": { "cursor": { "row": 1, "col": 5 } },
+  "goal": {
+    "all": [
+      { "type": "cursorAt", "row": 3, "col": 39 }
+    ]
+  },
+  "par": 12,                         // optimal keystrokes (for scoring/stars)
+  "solution": ["j", "j", "3", "9", "l"],  // replayed in CI to prove solvability
+  "hints": [
+    "j moves down one line.",
+    "A count like 39l repeats a motion."
+  ]
+}
+```
+
+### Goal / validator vocabulary
+
+The `goal` block is a small composable condition language evaluated against the engine's final state **and event log** (see GameEngine.md). This replaces every hardcoded win check that exists today:
+
+| Validator | Replaces today's… |
+|---|---|
+| `cursorAt {row, col}` | `level.target` |
+| `lineEquals {line, text}` | `level.targetText` |
+| `bufferEquals {lines, trimTrailing?: true}` | `level.targetContent` |
+| `exCommand {oneOf: ["q","wq"]}` | `level.exCommands` |
+| `searched {direction, query?, minNavigations?}` | level-name checks for search levels |
+| `performed {event, count?}` e.g. `{event:"undo"} + {event:"redo"}` sequence | `level12Undo`/`level12RedoAfterUndo` flags |
+| `sequence [validators…]` | ordered requirements ("undo, then redo") |
+| combinators `all`, `any`, `not` | ad-hoc boolean logic in `checkWinCondition` |
+
+Adding a new validator type is an engine change; *using* validators is pure content.
+
+### Track schema
+
+```jsonc
+// content/lessons/basics/track.json
+{
+  "id": "basics",
+  "title": "Vim Basics",
+  "description": "Survive your first Vim session.",
+  "order": ["exiting-vim", "hjkl-movement", "word-motion", "line-jumps"],
+  "unlocks": null            // or a track id that must be completed first
+}
+```
+
+Tracks give the Duolingo-style skill path without any code: the lesson browser renders whatever tracks exist.
+
+## Challenge schema
+
+```jsonc
+// content/challenges/quick-deletion.json
+{
+  "id": "quick-deletion",
+  "title": "Quick Deletion",
+  "description": "Delete and modify text rapidly!",
+  "timeLimit": 120,
+  "buffer": ["delete this remove line", "delete this line too", "This is BAD text"],
+  "tasks": [
+    {
+      "instruction": "Delete the word 'remove' using dw",
+      "hint": "Position cursor on 'r' of 'remove', then dw",
+      "goal": { "all": [ { "type": "lineEquals", "line": 0, "text": "delete this line" } ] }
+    }
+  ],
+  "scoring": { "taskPoints": 100, "timeBonusPerSecond": 1 }
+}
+```
+
+Identical `goal` vocabulary as lessons — one validator engine serves both. (Today's challenge validations are inline JS functions; those become data.)
+
+## Achievement schema
+
+```jsonc
+// content/achievements/achievements.json
+[
+  {
+    "id": "beginner",
+    "title": "Beginner",
+    "emoji": "🟢",
+    "description": "Completed the basic movement lessons.",
+    "rule": { "type": "trackCompleted", "track": "basics" }
+  },
+  {
+    "id": "searchmaster",
+    "title": "Search Master",
+    "emoji": "🔎",
+    "description": "Used / ? n N to search.",
+    "rule": { "type": "eventCount", "event": "search", "min": 1 }
+  },
+  {
+    "id": "speed-demon",
+    "title": "Speed Demon",
+    "emoji": "⚡",
+    "description": "Finished a challenge with 30+ seconds left.",
+    "rule": { "type": "challengeCompleted", "minTimeRemaining": 30 }
+  }
+]
+```
+
+Rules are declarative and evaluated by one `AchievementEngine` over the shared event stream. Today's three divergent badge maps (`ui-components.js`, `profile-page.js`, `sharing-system.js`) collapse into this file.
+
+## Command reference schema
+
+```jsonc
+// content/commands/commands.json
+[
+  {
+    "id": "dd",
+    "keys": "dd",
+    "category": "editing",
+    "summary": "Delete line",
+    "example": "Remove an entire line.",
+    "practiceLesson": "delete-line-practice"   // links cheat sheet → lesson
+  }
+]
+```
+
+The cheat sheet renders from this file; "Practice" buttons launch the linked lesson through the normal lesson runner — deleting `cheat-mode.js`'s duplicated `vimLessons` object.
+
+## Translations
+
+- `/content/i18n/<locale>.json` — flat UI string catalog (`"play": "Spielen"`).
+- Lesson localization by override file: `/content/i18n/de/lessons/hjkl-movement.json` supplies `title`, `instructions`, `hints`; `buffer` and `goal` stay canonical unless overridden. Missing keys fall back to English.
+
+## Validation & CI (the contract that keeps quality high)
+
+1. **Schema validation** — zod schemas in `src/core/content`; `npm run validate:content` checks every file (types, unique ids, goal validity, buffer bounds — e.g. `cursorAt` must lie inside `buffer`).
+2. **Solvability replay** — CI feeds each `solution` through the pure engine and asserts the `goal` passes. A lesson that can't be beaten can't be merged.
+3. **Par sanity** — warn when `solution.length` differs wildly from `par`.
+4. **Link check** — `commands`, `practiceLesson`, `track` references must resolve.
+
+## Loading strategy
+
+- Build step bundles content into per-track JSON chunks; the app lazy-loads a track on first open (keeps first paint small as content grows).
+- Content is versioned (`version` field) so future save-data migrations can adapt stored progress.
+
+## Migration from today's hardcoded content
+
+1. Write the schemas + loader; generate JSON from the existing `levels.js` array (16 lessons → `basics`/`editing`/`search` tracks).
+2. Port the four win-condition shapes 1:1, then add `searched`/`performed`/`sequence` validators and delete the level-name checks from the engine.
+3. Port the three challenges; delete their inline validation functions.
+4. Port badges to `achievements.json`; delete the three duplicated maps.
+5. Point the cheat sheet at `commands.json` + real lessons; delete `vimLessons`.
+
+After step 5, adding content requires zero application code — the definition of done for the platform vision.

--- a/docs/ContributingVision.md
+++ b/docs/ContributingVision.md
@@ -1,0 +1,99 @@
+# Contributing Vision
+
+Goal: **a first-time contributor adds a lesson within minutes** and a code contributor gets a green/red answer from CI without asking a maintainer.
+
+## Contributor personas & their golden paths
+
+| Persona | Path | Touches code? |
+|---|---|---|
+| Lesson author | copy a lesson JSON, edit, PR — CI proves it's solvable | No |
+| Translator | copy `content/i18n/en.json`, translate, PR | No |
+| Bug fixer | issue → failing test → fix → PR | Yes |
+| Engine contributor | grammar/motion work with table-driven tests | Yes |
+| Designer | themes (CSS variables), UI polish | Light |
+
+The content system (ContentSystem.md) is what makes the first two personas possible — protect that boundary in review: **content PRs must not require JS changes.**
+
+## Repository workflow
+
+- `main` is always deployable; deploys are automatic on merge.
+- Small PRs, one concern each. A PR that fixes a bug and refactors gets split.
+- Every PR: CI green (build, lint, test, content validation), no reduction in Lighthouse budget.
+- Conventional commits (`feat:`, `fix:`, `content:`, `docs:`) — enables changelog automation later.
+- Maintainer review within a few days; `good first issue`s get priority review as a policy (first-PR experience is the growth engine of an OSS project).
+
+## Files to add under `.github/`
+
+```
+.github/
+  ISSUE_TEMPLATE/
+    bug_report.yml         (repro steps, browser, save-code if relevant)
+    lesson_proposal.yml    (concept, buffer sketch, goal, par estimate)
+    feature_request.yml
+    config.yml             (links: Discussions for questions)
+  PULL_REQUEST_TEMPLATE/
+    pull_request_template.md   (checklist: tests, docs, screenshots for UI)
+  workflows/
+    ci.yml                 (build + lint + typecheck + test + validate:content)
+    deploy.yml             (Pages/Cloudflare on main)
+    lighthouse.yml         (budget check on PRs touching src/ or index.html)
+    content-preview.yml    (PR comment with a preview deploy link for content PRs)
+    stale.yml              (gentle nudge at 60 days, exempt `pinned`)
+  labels.yml               (declarative labels, synced by action)
+```
+
+## Suggested labels
+
+| Label | Use |
+|---|---|
+| `good first issue` | scoped, has pointers to exact files |
+| `help wanted` | maintainers won't get to it soon |
+| `content: lesson` / `content: challenge` / `content: i18n` | no-code contributions |
+| `engine` | Vim core / grammar work |
+| `ui` / `a11y` / `seo` / `perf` | shell concerns |
+| `bug` / `regression` | with severity via `P1`/`P2`/`P3` |
+| `needs repro` / `needs design` / `blocked` | status |
+| `breaking-save` | changes affecting stored progress/export codes — must include migration |
+
+## Suggested GitHub Actions detail
+
+**ci.yml** (required check):
+```yaml
+on: [pull_request, push]
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4        # with cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run validate:content      # schemas + solution replay
+      - run: npm run build
+```
+
+The **solution replay** step is the crown jewel: content contributors get "your lesson is unbeatable at step 3" as a CI message instead of a review comment.
+
+## Documentation set (target)
+
+- `CONTRIBUTING.md` — 5-minute quickstart: clone → `npm i` → `npm run dev`; links per persona
+- `docs/Lessons.md` — lesson authoring guide (exists)
+- `docs/ContentSystem.md` — schemas (exists)
+- `docs/GameEngine.md` — engine internals for code contributors (exists)
+- `CODE_OF_CONDUCT.md` — Contributor Covenant
+- `SECURITY.md` — even for a static site (dependency & XSS reports)
+
+## Folder-structure improvements for contributor clarity
+
+Current flat `js/` is fine at 11 files but the target structure (Architecture.md §2) is itself a contributor feature: `/content` says "edit here without fear", `/src/core` says "tests required here", `/src/features` says "UI lives here". Boundaries reduce review friction more than any style guide.
+
+## Community surfaces
+
+- **GitHub Discussions** — Q&A, lesson ideas, show-and-tell (share cards land here naturally)
+- **README badges** — CI, deploy, lesson count ("87 lessons and counting" auto-generated from content)
+- **`good first issue` curation ritual** — every refactor should deliberately leave 2–3 well-scoped starter issues behind
+- **CONTRIBUTORS recognition** — all-contributors bot; content authors credited in the lesson JSON (`author` field) and rendered in-game ("Lesson by @name")
+
+That last one matters: **in-game attribution** is the strongest incentive an educational OSS project can offer contributors.

--- a/docs/FeatureIdeas.md
+++ b/docs/FeatureIdeas.md
@@ -1,0 +1,54 @@
+# Feature Ideas
+
+A backlog of ideas, scored for impact vs. effort. Nothing here is committed — Roadmap.md holds the committed sequence. Inspirations noted: Duolingo (habit/progression), Vim Adventures (playfulness), Codewars/LeetCode (mastery ranking), TypeRacer (speed/competition).
+
+## High impact / low–medium effort
+
+| Idea | Notes |
+|---|---|
+| **Keystroke par + stars** | Score each lesson vs optimal keystrokes (`par` in content schema). 1–3 stars. Instantly adds replay value; engine already sees every key. |
+| **Daily challenge** | Deterministic pick from the challenge pool by date. "I solved today's VIMMaster daily in 14 keystrokes" share card. Habit loop with zero backend. |
+| **Streak counter** | Client-side day streak, shown on the progress bar. Cheap Duolingo magic. |
+| **Hint ladder** | Hints already exist in content; gate them: hint 1 free, hint 2 costs a star. Teaches self-sufficiency. |
+| **Mistake heatmap** | Track which commands the player fumbles (wrong-key events); surface "you should practice `b`" with a one-click practice lesson. |
+| **Command of the day** | Cheat-sheet entry surfaced on load with its practice lesson. Pure content reuse. |
+| **Solution replay** | After winning, show the par solution as an animated ghost cursor. Content files already carry `solution`. |
+| **PWA / installable + offline** | Manifest + service worker after the Vite migration. "Learn Vim on a plane." |
+
+## High impact / higher effort
+
+| Idea | Notes |
+|---|---|
+| **Text objects & visual mode tracks** | The single biggest credibility jump for real Vim learners. Needs the grammar engine (Phase 3). |
+| **Skill-tree lesson browser** | Duolingo-style map of tracks with locks/completion. Replaces the 1–16 button strip; makes 100+ lessons navigable. |
+| **Race your ghost** | Store best-run keystroke log per lesson; replay it as a second cursor while you play. TypeRacer feel, no backend. |
+| **Placement test** | 3-minute adaptive test that unlocks the right starting track for experienced users. |
+| **Sandbox / free-play buffer** | Empty buffer with the full emulator + live command log, for experimentation. Good SEO landing page too ("Vim playground online"). |
+| **Embeddable lesson widget** | `<iframe src=".../embed/dd-basics">` for blogs and docs. Growth loop: every embed is a backlink. |
+| **`.`-repeat and macro lessons** | Once the engine supports them — the "aha" commands that convert casual users to Vim converts. |
+
+## Community / competitive (needs infra decisions)
+
+| Idea | Notes |
+|---|---|
+| **Anonymous leaderboards** | Per daily challenge: name + score, Cloudflare Worker + KV (wrangler.toml already exists). First backend — keep optional and separate. |
+| **Golf mode** | Codegolf-style: same buffer transform, global fewest-keystrokes board. The Vim community *loves* vimgolf — huge shareability. |
+| **Community lesson gallery** | PR-based at first (content system makes this free); later a submission form that generates a PR. |
+| **Weekly tournament** | Rotating challenge set, results thread on GitHub Discussions. Zero backend if scores are share-card based. |
+
+## Polish / delight
+
+- Themes (gruvbox, catppuccin, solarized…) — CSS variables, community-contributable
+- Sound effects toggle (soft thock per keystroke, chime on win)
+- Konami-code style easter eggs (`:help hidden-level`)
+- Achievement rarity ("3% of players earned this")
+- Animated intro lesson ("You are trapped in Vim. Escape." — leans into the meme)
+- Keyboard layout awareness (Colemak/Dvorak notes on movement lessons)
+- Per-lesson "why this matters" blurb (real-world editing scenario)
+
+## Explicitly rejected (with reasons, to save future discussion)
+
+- **Accounts/logins** — kills privacy-first, adds cost and moderation burden; export codes cover portability
+- **Full Vim emulation** — infinite scope; we teach a curriculum, not replace Neovim
+- **Electron/desktop app** — the browser is the distribution advantage
+- **Ads** — trust and speed are the product

--- a/docs/GameEngine.md
+++ b/docs/GameEngine.md
@@ -1,0 +1,136 @@
+# Game Engine
+
+How the editor/engine works today, and the design for the engine VIMMaster grows into.
+
+## 1. Current engine
+
+### Input pipeline
+
+```
+hidden <textarea id="vim-editor-input"> keydown
+  → main.js keydown listener (modal/overlay guards)
+    → searchMode?  handleSearchMode(e)
+    → NORMAL?      handleNormalMode(e)
+    → else         handleInsertMode(e)
+  → updateUI()                      (full re-render)
+  → checkWinCondition() | checkPracticeCompletion()
+```
+
+- Focus is maintained by clicking the editor container; the textarea is transparent and absolutely positioned over the editor.
+- `Ctrl+[` is aliased to Escape (`game-state.js#isEscapeKey`).
+
+### Command recognition (normal mode)
+
+`vim-commands.js#handleNormalMode` — one function, ~380 lines:
+
+- **Counts**: digit keys accumulate in `countBuffer` (string); consumed by whichever command runs next; cleared on any non-digit.
+- **Single-key commands**: chained `if (key === 'h') …` blocks. Not `else if` — several can interact in one keystroke.
+- **Multi-key commands**: every printable key is appended to a `commandHistory` string; the handler checks `commandHistory.endsWith('dd' | 'dw' | 'gg' | 'cw' | 'yy')`. Requires manual guards (e.g. `w` movement is suppressed when history ends with `dw`/`cw`).
+- **Pending states**: `replacePending` flag for `r{char}`; `searchMode` flag for `/`/`?` input; ex commands parsed from the last `:` in `commandHistory` when Enter is pressed.
+- **Registers**: a single `yankedLine` (line-wise only).
+- **Undo**: explicit `pushUndo()` calls sprinkled before mutating commands (inconsistently — `a`/`o`/`O` push, `i` doesn't); stack of full state snapshots, capped at 200.
+
+### Supported command set
+
+Motions `h j k l w b e 0 $ gg G {n}G` · operators/edits `x dd dw cw D r yy p i a o O` · counts on most of these · `u` / `Ctrl+r` · search `/ ? n N` with highlighting · ex `:q :wq` (recognized, not executed).
+
+### Rendering
+
+`ui-components.js#renderEditor` rebuilds the whole editor as an HTML string per keystroke: one `div` per line, one `span` per character for cursor/search-match highlighting. At lesson sizes (≤10 lines) this is fine; the real cost today is the per-character `getSearchMatches()` defensive copy and the debug logging around it.
+
+### Weaknesses (details in TechnicalDebt.md)
+
+- String-suffix parsing is fragile and can't scale to operators+motions (`d3w`, `c$`, `dap`…).
+- State is global; the engine can't run headless, so nothing is unit-testable.
+- Win conditions partially live inside the engine keyed on level names.
+- Vim fidelity gaps in the taught subset (word motion semantics, undo granularity, insert-mode Enter).
+
+## 2. Target engine: a pure Vim core
+
+### Shape
+
+```ts
+// zero DOM, zero globals — a reducer
+dispatch(state: EditorState, input: KeyInput): DispatchResult
+
+interface DispatchResult {
+  state: EditorState;
+  events: EngineEvent[];   // what happened, for validators/telemetry
+}
+
+interface EditorState {
+  buffer: string[];
+  cursor: Position;
+  mode: Mode;                       // normal | insert | visual | search | command
+  pending: {                        // the parser state machine
+    count1?: number;                // count before operator
+    operator?: Operator;            // d, c, y, g-prefix, r…
+    count2?: number;                // count after operator
+    awaiting?: 'char' | 'motion';   // r{char}, f{char}, operator{motion}
+  };
+  registers: { unnamed: Register; [name: string]: Register };
+  undo: { stack: Snapshot[]; redo: Snapshot[] };
+  search: { query: string | null; direction: 1 | -1; matches: Match[]; index: number };
+  commandLine: string | null;       // ':' / '/' / '?' input buffer
+}
+```
+
+### Key/command grammar
+
+Replace suffix-matching with the actual Vim grammar as a small state machine:
+
+```
+command   := [count1] (operator [count2] motion | operator operator | simple)
+operator  := d | c | y | > | < | g~ …
+motion    := h j k l w b e W B E 0 ^ $ gg G f{c} t{c} / ? n N …
+simple    := i a A I o O x X r{c} p P u <C-r> D C s S ~ .
+```
+
+This makes `d3w`, `2dd`, `c$`, `3fx` fall out of the grammar instead of being special cases, and doubles (`dd`, `yy`, `cc`) are just `operator operator`.
+
+### Engine events → validation
+
+Every dispatch emits typed events, e.g.:
+
+```ts
+{ type: 'motion',   name: 'w', count: 3 }
+{ type: 'delete',   register: 'unnamed', linewise: true }
+{ type: 'search',   direction: 'forward', query: 'target' }
+{ type: 'searchNav', key: 'n' }
+{ type: 'undo' } | { type: 'redo' }
+{ type: 'ex',      command: 'wq' }
+{ type: 'modeChange', from: 'normal', to: 'insert' }
+```
+
+Lesson validators (ContentSystem.md) subscribe to the event log plus final state. This deletes every level-name check and per-level flag (`level12Undo` etc.) from the engine.
+
+### Correctness strategy
+
+- **Unit tests** on `dispatch`: table-driven `keys → expected buffer/cursor` cases, e.g. `["one two", "dw"] → "two"`. Hundreds of these are cheap once the core is pure.
+- **Fidelity oracle (optional, CI-only)**: a script replays the same key sequences through headless Neovim (`nvim --headless -es`) and diffs buffers — catching emulation drift for the taught subset without shipping any of it to the client.
+- **Golden lesson tests**: every lesson in `/content` ships a `solution` key sequence; CI replays it through the engine and asserts the lesson validates. This simultaneously tests engine, content, and validators, and guarantees no lesson is unsolvable.
+
+### Rendering contract
+
+The UI layer receives `EditorState` and renders. Optimizations when needed (not before):
+
+- render line-diffing (only re-render changed rows),
+- one span per *style run* rather than per character,
+- highlight decorations computed once per render, not per character.
+
+### What stays out of scope
+
+Full Vim (macros beyond `.`-repeat, splits, plugins, regex search flavors) is a non-goal. The engine implements exactly what the content teaches — but implements it correctly. New commands are added when a lesson needs them, together with tests.
+
+## 3. Game layer on top of the core
+
+```
+LessonRunner
+  load(lesson)       → initial EditorState from content file
+  onDispatch(result) → feed events to validators, detect completion/mistakes
+  scoring            → keystroke count vs par, time, hints used
+ChallengeRunner      → LessonRunner + timer + task sequence + scoring
+AchievementEngine    → declarative rules over the same event stream
+```
+
+All three consume content descriptors and the engine event stream only. That's the whole trick: **one event stream, many consumers** — validation, scoring, achievements, analytics, and (later) replay/ghost-cursor features like TypeRacer.

--- a/docs/Lessons.md
+++ b/docs/Lessons.md
@@ -1,0 +1,84 @@
+# Lessons
+
+How lessons work today, how to add one right now, and where lesson design is headed.
+
+## 1. How lessons work today
+
+A lesson ("level") is an object in the `levels` array in [`js/levels.js`](../js/levels.js):
+
+```js
+{
+    name: "Delete Basics",
+    instructions: "Use dd to delete the full middle line. …",
+    initialContent: [
+        "Keep this line.",
+        "Delete this entire line.",
+        "Fix this mistake here."
+    ],
+    targetContent: [                 // ← the win condition
+        "Keep this line.",
+        "Fix this here."
+    ],
+    setup: (gameState) => { gameState.cursor = { row: 0, col: 0 }; }
+}
+```
+
+### Win-condition types (exactly one per level)
+
+| Field | Meaning | Checked in |
+|---|---|---|
+| `target: {row, col}` | cursor reaches this position | `event-handlers.js#checkWinCondition` |
+| `targetText: {line, text}` | line `line` equals `text` (and mode is NORMAL) | same |
+| `targetContent: [lines]` | entire buffer equals (trailing whitespace/blank lines ignored) | same |
+| `exCommands: ["q","wq"]` | player executed one of these `:` commands | same |
+
+### Special cases you must know about (current caveats)
+
+- **Search levels** (`Search Forward (/)`, `Search Backward (?)`, `Search Navigation (n/N)`) are matched **by name** in `checkWinCondition` and additionally require the right search direction, the exact query (`target`/`alpha`/`foo`), and a minimum number of `n`/`N` presses. Renaming these levels breaks them.
+- **`Undo / Redo`** is matched by name in `vim-commands.js` and requires the undo→redo sequence via `level12Undo`/`level12RedoAfterUndo` flags.
+- **`setup()` currently doesn't work** — it receives a copy of the cursor and its changes are discarded (TechnicalDebt.md TD-2). Until fixed, every level effectively starts at `{0,0}`. Design lessons accordingly or fix TD-2 first.
+- Adding/removing a level changes `levels.length`; the progress validator hardcodes 15/14 (TD-1) and must be updated — another reason these numbers must be derived, not hardcoded.
+
+There is a **second, parallel lesson set**: `vimLessons` in `js/cheat-mode.js` powers the "Practice" buttons in Cheat Mode with the same shape (plus working `setup`). It is a drifted near-copy of the levels — treat any content change as needing both places checked until the content system unifies them.
+
+### Adding a lesson today (interim recipe)
+
+1. Append an object to the `levels` array with `name`, `instructions`, `initialContent`, and exactly one win-condition field.
+2. Prefer `targetContent`/`targetText`/`target` — avoid anything needing new engine flags.
+3. Verify coordinates are 0-based and inside the buffer (`target.col` counts characters, not display width).
+4. Update the hardcoded totals in `progress-system.js` (until TD-1 is fixed) and the "16 Progressive Levels" copy in `index.html`/README.
+5. Play it end-to-end, including winning it, and confirm the modal and next-level flow.
+
+## 2. Where lessons are headed
+
+The target format is one JSON file per lesson under `/content/lessons/<track>/` with declarative goals, a machine-checkable `solution`, `par` keystrokes, and hints — full schema in [ContentSystem.md](ContentSystem.md). CI replays the solution so a merged lesson is a provably solvable lesson.
+
+## 3. Lesson design guidelines (apply to both formats)
+
+**One concept per lesson.** Teach `dd` or teach `dw` — not both — then add a "combo" lesson afterwards that mixes them. (Today's "Delete Basics" teaches `dd`+`dw`+`x` at once; split candidates.)
+
+**Show, then remove scaffolding.** First lesson of a concept names the keys in the buffer text itself; later lessons stop mentioning keys and only state the outcome ("make the buffer look like this").
+
+**Buffer text is part of the lesson.** Use it for flavor and context, keep lines under ~60 chars (mobile), and never make the target character ambiguous (one `$` in the buffer, not three).
+
+**Win on outcomes, not keystrokes** — already the project's stated philosophy. The validator vocabulary exists so "used search, not 40 presses of `l`" can be expressed declaratively when the method *is* the point.
+
+**Difficulty ramp per track:** introduce → drill (2–3 quick variants) → combine with earlier concepts → challenge (timed, in Challenge Mode).
+
+**Par values** should be the true optimum; stars/scoring compare player keystrokes against par (Codewars/LeetCode-style efficiency ranking comes free once the engine counts keystrokes).
+
+## 4. Planned lesson tracks (content roadmap)
+
+| Track | Concepts | Status |
+|---|---|---|
+| Survival | `:q` `:wq` `:q!` modes, Esc | partial (level 1) |
+| Movement | `hjkl`, `wbe`, `0 $ ^`, `gg G {n}G`, `f t ; ,` | partial |
+| Editing | `x r`, `i a I A`, `o O`, `dd dw D`, `cw cc C`, `yy p P` | partial |
+| Counts & repeat | counts, `.` repeat | partial (counts only) |
+| Search | `/ ? n N *` | done (needs `*`) |
+| Text objects | `iw aw i" i( ip` + operators | missing (high value!) |
+| Visual mode | `v V Ctrl-v`, operators on selections | missing |
+| Ex essentials | `:%s`, ranges, `:g` | missing |
+| Registers & macros | named registers, `q` macros | missing (advanced track) |
+
+Text objects and visual mode are the biggest gaps between "toy" and "actually teaches Vim" — prioritize them once the engine grammar refactor lands (GameEngine.md), since both need the `operator + motion/textobject` parser.

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,0 +1,15 @@
+# Roadmap
+
+**The canonical roadmap now lives at [/ROADMAP.md](../ROADMAP.md)** (root of the repository), restructured around the phases:
+
+```
+Phase 0   Stabilize
+Phase 0.5 Developer Experience
+Phase 1   Architecture
+Phase 2   Content
+Phase 3   Platform
+Phase 4   Community
+Phase 5   Release
+```
+
+This file is kept as a pointer so links to `docs/Roadmap.md` don't break. Please update [/ROADMAP.md](../ROADMAP.md) only.

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -1,0 +1,94 @@
+# SEO Strategy
+
+VIMMaster competes for queries like *learn vim*, *vim tutorial*, *vim game*, *vim practice online*, *how to exit vim*. It is a static, fast site — structurally ideal for SEO — but currently ships almost no metadata.
+
+## Current state audit
+
+| Item | Status |
+|---|---|
+| Title | ⚠️ "VIM Master Game" (weak; no keywords, same everywhere) |
+| Meta description | ❌ none |
+| Open Graph / Twitter cards | ❌ none (shares render as bare links — painful for a project with a sharing feature) |
+| Favicon link | ❌ `images/favicon.ico` exists but no `<link rel="icon">` |
+| Canonical URL | ❌ none (site is served from at least two origins: github.io + Cloudflare — duplicate-content risk) |
+| robots.txt / sitemap.xml | ❌ none |
+| Structured data | ❌ none |
+| Crawlable text content | ⚠️ minimal — page is UI, near-zero indexable prose |
+| Headings | ⚠️ single `<h1>` is decorative ("VIM Master"), placed mid-page |
+| Performance | ⚠️ Tailwind CDN is render-blocking ~300 KB (also a Core Web Vitals issue) |
+| Mobile | ⚠️ playable-ish; viewport tag present |
+
+## Phase 0 — metadata quick wins (an afternoon, zero risk)
+
+`index.html`:
+
+```html
+<title>VIM Master — Learn Vim Interactively, Free in Your Browser</title>
+<meta name="description" content="Learn Vim the fun way: 16 interactive levels, speed challenges, and a built-in cheat sheet. Free, open source, no signup — plays entirely in your browser.">
+<link rel="canonical" href="https://renzorlive.github.io/vimmaster/">
+<link rel="icon" href="images/favicon.ico">
+
+<meta property="og:type" content="website">
+<meta property="og:title" content="VIM Master — Learn Vim Interactively">
+<meta property="og:description" content="Master Vim through interactive levels, timed challenges, and instant practice. Free & open source.">
+<meta property="og:image" content="https://renzorlive.github.io/vimmaster/images/vmrf.png">
+<meta property="og:url" content="https://renzorlive.github.io/vimmaster/">
+<meta name="twitter:card" content="summary_large_image">
+```
+
+Equivalent (distinct) title/description for `profile.html` + `noindex` consideration (it's personal-state UI; `noindex, follow` is reasonable).
+
+Also:
+- `robots.txt` allowing all + sitemap pointer; `sitemap.xml` with the two pages (grow later).
+- Pick **one canonical origin** (recommend the eventual custom domain, else github.io) and 301/`link rel=canonical` from the other.
+- JSON-LD structured data:
+
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "VIM Master",
+  "applicationCategory": "EducationalApplication",
+  "operatingSystem": "Any (Web)",
+  "offers": { "@type": "Offer", "price": "0" },
+  "description": "Interactive browser game that teaches Vim motions and editing commands.",
+  "url": "https://renzorlive.github.io/vimmaster/"
+}
+</script>
+```
+
+## Phase 1 — technical SEO via the build migration
+
+- Replace Tailwind CDN with compiled CSS (largest LCP win available).
+- Preload the editor font if a webfont is adopted; currently local fallbacks — fine.
+- Keep everything statically rendered: the game shell + an indexable prose section must exist in HTML, not injected by JS.
+- Add an on-page crawlable content block (below the fold): what VIMMaster is, what you'll learn, level list as real text. Right now a crawler sees almost no words; a ~300-word semantic section with `<h2>`s ("Learn Vim commands interactively", "16 progressive lessons", "Practice speed challenges") fixes that without touching gameplay.
+- Lighthouse CI budget in GitHub Actions guards regressions (ContributingVision.md).
+
+## Phase 2 — programmatic content pages (the growth engine)
+
+Once content is data (ContentSystem.md), generate a static page per command and per lesson at build time:
+
+```
+/commands/dd     "dd — delete line in Vim"     ← explainer + playable mini-lesson embed
+/commands/cw
+/lessons/basics/exiting-vim   "How to exit Vim (interactive lesson)"
+```
+
+- Each page: unique title/description, prose explanation, examples, the interactive embed, links to related commands (internal linking mesh), JSON-LD `LearningResource`.
+- *"how to exit vim"* alone is a massive evergreen query the level-1 lesson is literally built for — that page should exist and be excellent.
+- These pages are generated from the same JSON contributors write — SEO grows automatically with content, no separate authoring.
+
+## Phase 3 — off-page & distribution
+
+- Custom domain (e.g. `vimmaster.dev`) — consolidates signals and enables Cloudflare fully; set canonical + redirects from github.io.
+- Submit to: awesome-vim lists, r/vim & r/neovim (show-and-tell tone), Hacker News (post when text objects/golf mode ship — needs a hook), vim.fandom / Neovim wiki external-resources pages, alternativeto (Vim Adventures alternative — a real query).
+- The share-card feature already emits links; ensure shared URLs carry OG tags (Phase 0) so every player share is a well-rendered backlink.
+- Embeddable lesson widget (FeatureIdeas.md) turns blog embeds into backlinks.
+
+## Measurement
+
+- Google Search Console + Bing Webmaster (verify via meta tag, static-friendly).
+- Privacy-respecting analytics if any (Cloudflare Web Analytics / Plausible) — no cookies, aligned with the no-tracking ethos; or none at all and rely on Search Console.
+- KPI order: indexed pages → impressions on command queries → clicks → returning users (streak feature ties in).

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -1,0 +1,97 @@
+# Technical Debt Register
+
+Severity: 🔴 breaks users · 🟠 blocks the platform vision · 🟡 quality/maintainability · ⚪ polish
+
+Each item is small enough to be one reviewable PR unless noted.
+
+## 🔴 Bugs (fix first, no refactoring required)
+
+### TD-1 Progress validation off-by-one destroys saves
+`js/progress-system.js:129` rejects `currentLevel > 14` and `getProgressSummary()` reports `totalLevels: 15`, but `levels.js` defines **16** levels. A player who reaches the last level gets their save rejected on next load — and `autoLoadProgress()` then **deletes** it (`localStorage.removeItem`). Same magic number appears in `sharing-system.js:20`.
+**Fix:** derive from `levels.length` everywhere; never hard-delete on validation failure (keep a backup key).
+
+### TD-2 Level `setup()` never takes effect
+`js/levels.js:259-264` calls `level.setup({ cursor: getCursor(), ... })`. `getCursor()` returns a copy; the setup mutates the copy; nothing is written back. Every level starts at `{row:0, col:0}` even though 12 of 16 levels specify another start position. (Cheat-mode lessons do write the result back — `cheat-mode.js:474-486` — which is why they behave differently.)
+**Fix:** apply `gameState.cursor`/`commandHistory` back via setters after `setup()` runs, mirroring cheat-mode.
+
+### TD-3 Auto-save-on-completion never fires
+`js/main.js:463-476` wraps `window.checkWinCondition`, but `checkWinCondition` is an ES-module export that is never assigned to `window`. The wrapper is dead code; only the 30-second interval save works.
+**Fix:** call `autoSaveProgress()` from the actual win path in `checkWinCondition()`.
+
+### TD-4 Stale-state bounds clamp in normal mode
+`js/vim-commands.js:404-410` clamps `cursor` captured at function entry, not the post-command cursor, so the safety net evaluates stale values.
+**Fix:** re-read cursor via `getCursor()` before clamping (or fix properly during the pure-core refactor).
+
+### TD-5 `0` is unreachable as a motion
+`vim-commands.js:64-70` routes `0` into the count buffer unless the buffer is empty, then line 239 also treats `0` as "go to line start" — but only when the count buffer is empty, and `$`'s handler at line 240 runs even when `$` was typed during a pending count. Behavior around `10j`, `0`, `d0` is inconsistent. Verify with tests once the core is testable.
+
+### TD-6 Duplicate, divergent challenge logic
+`challenges.js#checkChallengeTask` and `#endChallenge` are never called; scoring was re-implemented in `event-handlers.js#checkWinCondition` with different point values (10 + time/10 vs 100 + timeBonus). One source of truth must win.
+**Fix:** delete the dead functions or (better) move scoring back into `challenges.js` and call it.
+
+## 🟠 Platform blockers
+
+### TD-7 Engine hardcodes knowledge of specific levels
+- Level-name string matching: `'Undo / Redo'` in `vim-commands.js:113,395`; `['Search Forward (/)','Search Backward (?)','Search Navigation (n/N)']` in `event-handlers.js:160,236` (duplicated twice).
+- Dedicated global state flags for one level: `level12Undo`, `level12RedoAfterUndo`.
+- Search levels enforce query text (`'target'`, `'alpha'`, `'foo'`) inline in `checkWinCondition`.
+
+This makes adding content require engine edits — the opposite of the data-driven goal.
+**Fix:** add declarative validator types to the level schema (e.g. `requires: [{type:'search', direction:'forward', query:'target', minNavigations:1}]`, `{type:'undoThenRedo'}`) evaluated against an event log. See ContentSystem.md.
+
+### TD-8 Content duplicated between levels and cheat-mode lessons
+`cheat-mode.js#vimLessons` (16 lessons, ~310 lines) is a near-copy of `levels.js` content with drift already visible. Both should be entries in one content store, tagged for where they appear.
+
+### TD-9 No package.json / build / lint / tests / CI
+There is no way to programmatically verify anything. Every other fix lands blind. Bootstrap: `package.json`, Vite, ESLint + Prettier, vitest, one GitHub Action running `build + lint + test`. (See ContributingVision.md for workflow.)
+
+### TD-10 Tailwind via CDN
+`<script src="https://cdn.tailwindcss.com">` is a ~300 KB render-blocking script that Tailwind explicitly says is not for production, generates styles at runtime, and logs a console warning. Replace with build-time Tailwind (or a small hand-rolled CSS file) during the Vite step. Also an offline/PWA blocker.
+
+## 🟡 Maintainability
+
+### TD-11 Shipped debug logging
+~150 `console.log('🔍 DEBUG…')` calls across `event-handlers.js`, `challenges.js`, `progress-system.js`, `ui-components.js`, `cheat-mode.js`, `main.js` — several dump full buffer content **on every keystroke** (`updateUI`). Remove entirely; if diagnostics are wanted, gate behind a `DEBUG` flag.
+
+### TD-12 Duplicated utility logic
+- `stripTrailingBlankLines`/`trimLineEnd` content comparison: `event-handlers.js:189-199` and `cheat-mode.js:620-636`.
+- ASCII logo: `index.html`, `sharing-system.js` canvas array, `sharing-system.js#generateAsciiLogo` (3 copies).
+- Challenge task instruction HTML template: `event-handlers.js:91-97` and `ui-components.js:147-153`.
+- Badge id → emoji/label/description maps: `ui-components.js:212`, `profile-page.js:256`, `sharing-system.js:712` (3 divergent copies).
+- Progress loading: `profile-page.js#loadProgressData` re-implements `progressSystem.autoLoadProgress()` without validation.
+
+### TD-13 `game-state.js` getter/setter explosion
+~70 exported functions; call sites import 30+ names each (`main.js` imports 44). The defensive-copy getters also mean hot paths (`renderEditor`'s per-character `isInMatch`) copy the match array **per character rendered**. Replace with a single state object + narrow update API during the core refactor; short-term, hoist `getSearchMatches()` out of the render loop.
+
+### TD-14 `handleNormalMode` is a 380-line conditional
+Command parsing by `commandHistory.endsWith(...)` is fragile (e.g. any key sequence *ending* in `dd` triggers delete; `w` needs an explicit guard against `dw`/`cw`). Needs a real `count → operator → motion` parser (GameEngine.md).
+
+### TD-15 Inline `onclick` + string-interpolated HTML
+`sharing-system.js` and `profile-page.js` build large HTML strings with inline styles and `onclick="sharingSystem.…({name: '${…}'})"` — breaks on quotes in data, requires globals on `window`, and is an XSS hazard the moment content becomes contributor-supplied. Modal buttons in `event-handlers.js:128-133` use the same pattern (`window.startNewChallenge`).
+
+### TD-16 Timer and interval hygiene
+- `main.js` runs two unconditional `setInterval`s (5 s UI refresh, 30 s save) forever.
+- Challenge timer is managed both in `event-handlers.js` (local `timerInterval`) and `game-state.js` (`_challengeTimerInterval`), with the stuck-state patch in `updateUI` (`Fixing stuck challenge mode state`) papering over lifecycle confusion.
+
+### TD-17 Vim fidelity gaps in taught commands
+Within the subset the game teaches: `b` only understands spaces (punctuation breaks it), `w` uses `\s\S` (skips punctuation semantics), `cw` deletes to whitespace rather than word end, `i` doesn't push undo while `a`/`o`/`O` do, insert-mode Enter doesn't split lines, `p` with a count pastes N copies in reverse order (prepending at the same row). Fine for v1; must be right (and tested) in the pure core.
+
+## ⚪ Polish
+
+### TD-18 SEO/meta absent
+No meta description, canonical, Open Graph/Twitter cards, favicon `<link>`, robots.txt, sitemap, or structured data. Title is "VIM Master Game". Full plan in SEO.md — these are cheap, high-value, zero-risk additions.
+
+### TD-19 Accessibility
+No ARIA roles/labels, modals lack focus traps, color-only mode indication, hidden-textarea focus model undiscoverable to screen readers, no `prefers-reduced-motion` handling for confetti/particles.
+
+### TD-20 `profile.html` duplicates head/styles inline
+~180 lines of page-specific CSS inline in `<style>`; extract to shared stylesheet during the Vite step.
+
+## Suggested burn-down order
+
+1. TD-1..TD-4, TD-6 (bug fixes, individually shippable)
+2. TD-11 (log strip) + TD-18 (meta tags) — trivial wins
+3. TD-9 → TD-10 (tooling, then Tailwind build)
+4. TD-7 + TD-8 via the content extraction (ContentSystem.md)
+5. TD-13 + TD-14 + TD-17 via the pure-core refactor (GameEngine.md)
+6. TD-12, TD-15, TD-16, TD-19, TD-20 opportunistically alongside

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,22 @@
+# ADR-0001: Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+
+## Context
+
+VIMMaster aims to become a multi-contributor open-source platform ("The Open Source Home for Learning Vim"). Projects at that scale repeatedly re-argue old decisions unless the reasoning is written down. New contributors also need a way to learn *why* things are the way they are without archaeology through PR threads.
+
+## Decision
+
+We record every significant technical decision as an Architecture Decision Record in `docs/adr/`, using the template in this directory. Big changes go through an RFC (GitHub issue with the RFC template → discussion → accepted) and are then condensed into an ADR. ADRs are immutable; reversals happen via superseding ADRs.
+
+## Alternatives considered
+
+- **Decisions in PR descriptions/discussions only** — where they live today; unfindable within months.
+- **A single DECISIONS.md** — becomes an unstructured wall; no lifecycle per decision.
+- **Full RFC repository (Rust-style)** — heavier than a project this size needs; the issue-template RFC + ADR condensation gives 90% of the value.
+
+## Trade-offs / consequences
+
+Small writing overhead per big decision; in exchange, contributor onboarding and long-term maintainability improve, and "why?" questions get a link instead of a debate.

--- a/docs/adr/0002-build-tooling-and-ui-framework.md
+++ b/docs/adr/0002-build-tooling-and-ui-framework.md
@@ -1,0 +1,30 @@
+# ADR-0002: Vite + TypeScript build, Preact UI shell, pure-TS Vim core
+
+- **Status:** Proposed *(to be confirmed via RFC before Phase 0.5 tooling work merges)*
+- **Date:** 2026-07-09
+- **RFC/Discussion:** TBD
+
+## Context
+
+The project is currently zero-build vanilla JS with Tailwind via CDN. That keeps contribution friction at zero but blocks: type safety, tests, dead-code elimination, removing the non-production Tailwind CDN script, content bundling/validation, and the generated SEO pages planned in the roadmap. The platform vision (docs/Architecture.md) needs a build step; the question is which stack, chosen to preserve speed and contributor-friendliness.
+
+## Decision
+
+1. **Vite + TypeScript** as build tooling. Output remains a fully static site (GitHub Pages / Cloudflare).
+2. **The Vim core is pure TypeScript with zero DOM and zero framework dependency** — a `dispatch(state, key) → state` reducer (docs/GameEngine.md). This is non-negotiable regardless of UI choices.
+3. **Preact (with the React compat alias) for the UI shell**, migrated feature by feature. Contributors write standard React/TSX; the runtime costs ~4 KB.
+4. **Tailwind as a build-time dependency**, replacing the CDN script.
+
+## Alternatives considered
+
+- **Stay vanilla JS forever** — lowest friction today, but hand-rolled rendering and no verification tooling scale badly past ~10 UI surfaces (lesson browser, docs, playgrounds, i18n are coming). Rejected for the platform vision, kept for as long as possible (Phase 0 fixes happen pre-build).
+- **React proper** — maximum contributor familiarity, ~45 KB baseline for a game whose core view is a `<pre>`. Preact's compat alias gives the same DX; switching later is a one-line alias change, which is why Preact wins.
+- **Svelte/Solid** — excellent runtimes, smaller contributor pools; contributor familiarity is a first-class goal here.
+- **Webpack/Parcel/esbuild-raw** — Vite is the current community default with the best DX; no reason to deviate.
+
+## Trade-offs / consequences
+
+- Contributors now need Node + `npm install` (documented in CONTRIBUTING; quickstart stays under 15 minutes).
+- A build step means CI must guard it (Phase 0.5 GitHub Actions).
+- The pure-core rule means UI churn can never break editing logic, and the emulator is testable headlessly — the foundation for solution-replay CI and the Neovim fidelity oracle.
+- If Preact ever becomes limiting, the compat alias makes React a migration, not a rewrite.

--- a/docs/adr/0003-content-as-data.md
+++ b/docs/adr/0003-content-as-data.md
@@ -1,0 +1,26 @@
+# ADR-0003: All content is data; the engine knows no content
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+
+## Context
+
+Lessons, challenges, achievements, and the command reference are currently hardcoded in JavaScript, partially duplicated (levels vs. cheat-mode lessons; three badge maps), and the engine contains level-specific logic (level-name string checks, per-level flags). Every content addition requires code changes and code review — the opposite of a contributor-friendly content platform. The mission ("The Open Source Home for Learning Vim") depends on non-programmers adding lessons and translations.
+
+## Decision
+
+All content — lessons, challenges, achievements, tutorials, command reference, translations — lives in declarative JSON files under `/content`, validated by schemas, with win conditions expressed in a composable validator vocabulary evaluated against the engine's event stream. The engine may gain new *validator types*; it must never reference a specific piece of content. Every lesson ships a `solution` key sequence that CI replays through the engine to prove solvability before merge.
+
+Full schemas: docs/ContentSystem.md.
+
+## Alternatives considered
+
+- **Keep content in JS modules** — flexible (arbitrary validation functions) but requires JS review for every lesson, allows unbounded logic in content, and prevents no-code contribution, schema validation, and generated SEO pages.
+- **Markdown + frontmatter per lesson** — friendlier to write, but goals/buffers need structure anyway; JSON with a good template + the contributor playground (load a `lesson.json` live, no PR) wins. Markdown remains an option for *tutorial prose* later.
+- **CMS/database** — infrastructure, cost, and a second source of truth; git-based content keeps review, history, and attribution for free.
+
+## Trade-offs / consequences
+
+- The validator vocabulary must grow deliberately (each new type is engine work + tests) — a feature, not a bug: it keeps content declarative.
+- One-time migration cost for the 16 existing levels, 3 challenges, badges, and the cheat sheet — which also deletes their current duplications.
+- Enables: solution-replay CI, generated `/commands/*` SEO pages, docs-site command reference, i18n overrides, and the contributor playground — all from the same files.

--- a/docs/adr/0004-no-backend-by-default.md
+++ b/docs/adr/0004-no-backend-by-default.md
@@ -1,0 +1,26 @@
+# ADR-0004: No backend by default; localStorage + export codes for persistence
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+
+## Context
+
+VIMMaster is a free, privacy-first, static site. Progress persistence currently uses localStorage plus Base64 export/import codes. Roadmap features tempt a backend: leaderboards, community lesson submission, analytics. Backends bring cost, accounts, moderation, GDPR surface, and a single point of failure — all hostile to a volunteer-run OSS project.
+
+## Decision
+
+The core product must remain **fully functional as a static site with no backend and no accounts**. Persistence stays localStorage + export codes. Features that genuinely need a server (anonymous leaderboards, opt-in analytics beacon) may be added as **optional, degradable extras** on Cloudflare Workers/KV (deployment already targets Cloudflare), each requiring its own RFC + ADR, and the game must work identically with them unreachable.
+
+Analytics specifically: **no Google Analytics or third-party trackers.** Own event vocabulary (lesson started/finished, command failed, retries, drop-off), aggregated locally first; any network transmission is anonymous, opt-in, and served from our own Worker.
+
+## Alternatives considered
+
+- **Accounts + database (Firebase/Supabase/etc.)** — enables sync and social features, but kills privacy-first positioning, adds cost/moderation/compliance, and gates contributions on infrastructure access. Rejected.
+- **Third-party analytics (GA, even Plausible-hosted)** — GA is rejected outright (privacy, weight, trust); privacy-respecting hosted options remain acceptable *fallbacks* but own-events give product insight (most-failed lesson) that pageview tools cannot.
+- **Pure no-server forever** — simplest, but forecloses leaderboards/golf-mode community features that fit the mission; the "optional and degradable" rule keeps the door open safely.
+
+## Trade-offs / consequences
+
+- No cross-device sync (export codes are the manual escape hatch) — accepted.
+- Community features must be designed to degrade (e.g., share-card-based tournaments before live leaderboards).
+- Every server-touching feature carries RFC overhead by design — friction that protects the project's core promise: **open the page, learn Vim, no strings.**

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# Architecture Decision Records (ADRs)
+
+Every significant technical decision in VIMMaster is recorded here: **why** it was made, what **alternatives** were considered, and what **trade-offs** were accepted. This is how a project survives maintainer turnover and contributor growth without re-litigating the past — and how it *deliberately* revisits the past when circumstances change.
+
+## When to write an ADR
+
+Write one when a decision:
+- changes architecture, the content schema, or the save-data format,
+- adds/removes a dependency or a build tool,
+- commits to or rejects a whole approach (backend? framework? analytics?),
+- would make a future contributor ask "why on earth is it like this?"
+
+Big decisions should go through the [RFC process](../../CONTRIBUTING.md#rfc-process-big-changes) first; the accepted RFC is then condensed into an ADR.
+
+## Format
+
+One file per decision: `NNNN-short-title.md`, numbered sequentially, using [the template](template.md). Statuses: `Proposed` → `Accepted` → `Implemented`, or `Rejected` / `Superseded by ADR-XXXX`.
+
+ADRs are **immutable history**: to reverse a decision, write a new ADR that supersedes the old one — don't edit the old one beyond updating its status line.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0002](0002-build-tooling-and-ui-framework.md) | Vite + TypeScript build, Preact UI shell, pure-TS Vim core | Proposed |
+| [0003](0003-content-as-data.md) | All content is data, engine knows no content | Accepted |
+| [0004](0004-no-backend-by-default.md) | No backend by default; localStorage + export codes | Accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,21 @@
+# ADR-NNNN: Title
+
+- **Status:** Proposed | Accepted | Implemented | Rejected | Superseded by ADR-XXXX
+- **Date:** YYYY-MM-DD
+- **RFC/Discussion:** link (if any)
+
+## Context
+
+What problem are we solving? What forces are at play (constraints, goals, prior decisions)?
+
+## Decision
+
+What we chose, stated plainly and specifically.
+
+## Alternatives considered
+
+For each serious alternative: what it is, why it was attractive, why it lost.
+
+## Trade-offs / consequences
+
+What we gain, what we give up, what becomes harder, what future decisions this constrains. Include migration/rollback notes if relevant.

--- a/images/banner.svg
+++ b/images/banner.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="360" viewBox="0 0 1280 360" role="img" aria-label="VIM Master — Learn Vim. Together.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="1" stop-color="#0b0f1a"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#facc15"/>
+      <stop offset="1" stop-color="#fb923c"/>
+    </linearGradient>
+    <style>
+      .mono { font-family: 'Fira Code', 'Cascadia Code', Consolas, Menlo, monospace; }
+      .sans { font-family: ui-sans-serif, 'Segoe UI', Helvetica, Arial, sans-serif; }
+    </style>
+  </defs>
+
+  <!-- background -->
+  <rect width="1280" height="360" fill="url(#bg)"/>
+  <!-- subtle dot grid -->
+  <g fill="#ffffff" opacity="0.04">
+    <circle cx="60" cy="40" r="2"/><circle cx="160" cy="90" r="2"/><circle cx="90" cy="200" r="2"/>
+    <circle cx="200" cy="300" r="2"/><circle cx="1120" cy="60" r="2"/><circle cx="1220" cy="150" r="2"/>
+    <circle cx="1150" cy="280" r="2"/><circle cx="1040" cy="330" r="2"/><circle cx="340" cy="40" r="2"/>
+  </g>
+
+  <!-- editor window -->
+  <g>
+    <rect x="64" y="56" width="560" height="248" rx="14" fill="#1e1e1e" stroke="#374151" stroke-width="1.5"/>
+    <!-- title bar -->
+    <rect x="64" y="56" width="560" height="38" rx="14" fill="#161616"/>
+    <rect x="64" y="80" width="560" height="14" fill="#161616"/>
+    <circle cx="92" cy="75" r="6" fill="#ef4444"/>
+    <circle cx="114" cy="75" r="6" fill="#facc15"/>
+    <circle cx="136" cy="75" r="6" fill="#22c55e"/>
+    <text x="344" y="80" text-anchor="middle" class="mono" font-size="13" fill="#6b7280">~/lessons/basics.vim</text>
+
+    <!-- buffer lines -->
+    <g class="mono" font-size="16">
+      <text x="92" y="128" fill="#4b5563">1</text>
+      <text x="120" y="128" fill="#9ca3af">Learning Vim is <tspan fill="#f2c55c">awesome!</tspan></text>
+
+      <text x="92" y="158" fill="#4b5563">2</text>
+      <text x="120" y="158" fill="#9ca3af">Move with h j k l</text>
+
+      <text x="92" y="188" fill="#4b5563">3</text>
+      <text x="120" y="188" fill="#9ca3af">Delete a line with dd</text>
+
+      <text x="92" y="218" fill="#4b5563">4</text>
+      <!-- cursor block on the target -->
+      <rect x="119" y="203" width="11" height="20" rx="2" fill="#f2c55c"/>
+      <text x="120" y="218" fill="#1e1e1e">:</text>
+      <text x="132" y="218" fill="#9ca3af">wq</text>
+      <text x="92" y="248" fill="#4b5563">~</text>
+      <text x="92" y="272" fill="#4b5563">~</text>
+    </g>
+
+    <!-- status bar -->
+    <rect x="82" y="268" width="150" height="24" rx="6" fill="url(#accent)"/>
+    <text x="157" y="285" text-anchor="middle" class="mono" font-size="13" font-weight="700" fill="#111827">-- NORMAL --</text>
+    <text x="600" y="285" text-anchor="end" class="mono" font-size="13" fill="#6b7280">4,1  All</text>
+  </g>
+
+  <!-- wordmark + slogan -->
+  <g>
+    <text x="688" y="150" class="mono" font-size="58" font-weight="700" fill="#e5e7eb">VIM<tspan fill="url(#accent)"> MASTER</tspan></text>
+    <text x="692" y="204" class="sans" font-size="34" font-weight="700" fill="#f2c55c">Learn Vim. Together.</text>
+    <text x="692" y="240" class="sans" font-size="19" fill="#9ca3af">The open-source platform for mastering Vim.</text>
+    <g class="mono" font-size="14" fill="#6b7280">
+      <text x="692" y="286">free · no signup · works offline · open source</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## What does this PR do?

Adds the complete governance and contributor infrastructure agreed before Phase 0: VISION, PROJECT_PRINCIPLES, NON_GOALS, DECISIONS, PROJECT_STATUS, ROADMAP, CONTRIBUTING (15-minute quickstart), CODE_OF_CONDUCT, SECURITY, GitHub issue/PR/RFC templates, the ADR system with 4 founding records, the full /docs architecture suite, the README banner, and the 'Learn Vim. Together.' positioning.

## Type of change

- [x] 📖 Docs

## How was it verified?

Docs-only: links cross-checked; banner SVG renders in preview.

## Notes for the reviewer

PR #(fix/td-1-save-corruption) is stacked on this branch — merge this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)