### PR TITLE
fix: single lesson-initialization pipeline — lesson config can no longer be ignored (TD-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: se
 
 ### Fixed
 
+- **Level start positions now apply.** `loadLevel()` discarded the result of each level's `setup()`, so every level started at `{0,0}` despite its configuration. Lessons (game levels and cheat-mode practice) now initialize through a single pipeline ([docs/architecture/level-lifecycle.md](docs/architecture/level-lifecycle.md)) with a consumption invariant: every lesson property must be consumed exactly once during initialization — unconsumed or malformed configuration is reported immediately instead of silently ignored ([ADR-0005](docs/adr/0005-lesson-initialization-pipeline.md)).
 - **Saves are no longer destroyed after finishing the game** ([PM-0001](docs/postmortems/PM-0001-save-corruption.md)). The progress validator hardcoded a 15-level range while the game has 16 levels; reaching the final level made the save "invalid", and the loader deleted it on the next visit. All level counts are now derived from `levels.length`.
 - **Invalid saves are repaired, never deleted.** The load path is now: load → validate → repair → otherwise keep the original, write a backup (`vimMasterProgressBackup`), and notify the player. The age-based save rejection (saves older than 1 year were deleted) is removed.
 - **Saved level is actually resumed.** Loading previously applied the saved level to state but then always started the session at level 1.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -9,7 +9,7 @@
 | **Current version** | pre-1.0 (unversioned; semver starts with the first tagged release in Phase 0.5) |
 | **Current phase** | ✅ Phase 0.5 docs/infra complete → ▶️ **entering Phase 0 — Stabilize** ([ROADMAP.md](ROADMAP.md)) |
 | **Current sprint** | Critical bug fixes, one PR each |
-| **Current focus** | TD-1 ✅ fixed ([PM-0001](docs/postmortems/PM-0001-save-corruption.md)) — next up: **TD-2** (level start positions ignored) |
+| **Current focus** | TD-1 ✅ · TD-2 ✅ ([ADR-0005](docs/adr/0005-lesson-initialization-pipeline.md)) — next up: **Phase 0.6 — logger** (replace ~150 debug logs), then testing, then CI |
 | **Next milestone** | *Stable v0.1*: all Phase 0 boxes checked — 5 bug fixes, debug logging stripped, SEO meta tags |
 | **Release target** | v1.0 after Phases 0–3 (engine rewrite + content system + platform pages) — no date commitment; quality gates over deadlines |
 
@@ -18,7 +18,7 @@
 | # | Issue | Severity |
 |---|---|---|
 | TD-1 | ~~Progress save rejected & deleted after the final level~~ ✅ fixed — [PM-0001](docs/postmortems/PM-0001-save-corruption.md) | ✅ |
-| TD-2 | Per-level cursor start positions silently ignored (`setup()` result discarded) | 🔴 |
+| TD-2 | ~~Per-level cursor start positions silently ignored~~ ✅ fixed — [ADR-0005](docs/adr/0005-lesson-initialization-pipeline.md) | ✅ |
 | TD-3 | Auto-save on level completion never fires (dead `window` hook) | 🔴 |
 | TD-6 | Duplicate, divergent challenge scoring implementations | 🔴 |
 | TD-11 | ~150 debug `console.log`s ship to production, some per-keystroke | 🟡 |

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -10,7 +10,7 @@ Each item is small enough to be one reviewable PR unless noted.
 `js/progress-system.js:129` rejects `currentLevel > 14` and `getProgressSummary()` reports `totalLevels: 15`, but `levels.js` defines **16** levels. A player who reaches the last level gets their save rejected on next load — and `autoLoadProgress()` then **deletes** it (`localStorage.removeItem`). Same magic number appears in `sharing-system.js:20`.
 **Fix:** derive from `levels.length` everywhere; never hard-delete on validation failure (keep a backup key).
 
-### TD-2 Level `setup()` never takes effect
+### TD-2 Level `setup()` never takes effect — ✅ FIXED ([ADR-0005](adr/0005-lesson-initialization-pipeline.md), [level-lifecycle.md](architecture/level-lifecycle.md))
 `js/levels.js:259-264` calls `level.setup({ cursor: getCursor(), ... })`. `getCursor()` returns a copy; the setup mutates the copy; nothing is written back. Every level starts at `{row:0, col:0}` even though 12 of 16 levels specify another start position. (Cheat-mode lessons do write the result back — `cheat-mode.js:474-486` — which is why they behave differently.)
 **Fix:** apply `gameState.cursor`/`commandHistory` back via setters after `setup()` runs, mirroring cheat-mode.
 

--- a/docs/adr/0005-lesson-initialization-pipeline.md
+++ b/docs/adr/0005-lesson-initialization-pipeline.md
@@ -1,0 +1,35 @@
+# ADR-0005: Single lesson-initialization pipeline with a consumption invariant
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+- **Origin:** TD-2 — lesson `setup()` results were silently discarded; every level started at `{0,0}` regardless of its configuration
+
+## Context
+
+Lesson initialization existed twice: `levels.js#loadLevel` (broken — it passed copies to `setup()` and discarded the result) and `cheat-mode.js#startCheatPractice` (working — it wrote the result back). The engine happily accepted configuration it then ignored; the bug was invisible because nothing checked that lesson data was actually used. With the JSON content system coming (ADR-0003), "engine silently ignores a content field" would become a recurring class of contributor-facing bug: a new field in a lesson file that does nothing, with no error anywhere.
+
+## Decision
+
+1. **One initializer.** All lesson-shaped content (game levels, cheat-mode practice, future JSON lessons) is initialized by a single function, `initializeLessonState(lesson)` in `levels.js`. Parallel init code paths are not accepted in review.
+2. **The consumption invariant:** *every lesson property must be consumed exactly once during initialization.* The initializer reads properties through a tracking reader and reports any property that exists on the lesson but was never read, immediately. Exactly one win-condition property is required and registered as the objective.
+3. **Corrective failure policy:** invalid configuration is repaired-and-reported where safe (out-of-bounds cursor → clamped + warning) and refused where not (missing/empty buffer → lesson does not load). Configuration is never silently ignored and state is never silently corrupted.
+4. **Documented pipeline:** the load → validate → initialize → position → render → start sequence is specified in [docs/architecture/level-lifecycle.md](../architecture/level-lifecycle.md), which is the single source of truth.
+5. **Future direction (recorded now, implemented in Phase 1):** initialization becomes a pure function
+
+   ```ts
+   initializeLesson(level): { buffer, cursor, objectives, metadata, state }
+   ```
+
+   returning a complete state object consumed by the pure engine core, replacing the current mutate-global-state approach and the mutable `setup(gameState)` convention. `validateLessonSchema()` (zod, CI-run) replaces the runtime shape guards when the Phase 2 content system lands.
+
+## Alternatives considered
+
+- **Just write the setup result back** (minimal bug fix) — repairs the symptom, leaves two init paths and no protection against the next ignored field. Rejected: the cause is architectural.
+- **Throw on unconsumed properties** — strictest enforcement, but a typo in one lesson would brick the game for players. Warn loudly at runtime now; *throw in CI* once schema validation exists (best of both).
+- **Freeze/proxy the lesson object to detect reads engine-wide** — heavier machinery for the same guarantee; the tracking reader is ~10 lines and lives where the invariant is defined.
+
+## Trade-offs / consequences
+
+- New lesson fields require touching the initializer (adding them to the known-properties consumption) — intentional friction: a field's meaning must be defined before it can exist.
+- Win-condition properties are *registered* at init and *evaluated* at play time; the invariant covers presence/registration, not evaluation correctness — that's what solution-replay CI (ADR-0003) is for.
+- The `setup()` mutable-object convention survives until Phase 1 solely for compatibility; the pure `initializeLesson` shape above is the committed target.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@ ADRs are **immutable history**: to reverse a decision, write a new ADR that supe
 | [0002](0002-build-tooling-and-ui-framework.md) | Vite + TypeScript build, Preact UI shell, pure-TS Vim core | Proposed |
 | [0003](0003-content-as-data.md) | All content is data, engine knows no content | Accepted |
 | [0004](0004-no-backend-by-default.md) | No backend by default; localStorage + export codes | Accepted |
+| [0005](0005-lesson-initialization-pipeline.md) | Single lesson-initialization pipeline with a consumption invariant | Accepted |

--- a/docs/architecture/level-lifecycle.md
+++ b/docs/architecture/level-lifecycle.md
@@ -1,0 +1,62 @@
+# Level / Lesson Lifecycle
+
+The single source of truth for how a lesson goes from a definition object to a playable state. Any code that initializes a lesson — `loadLevel()` for game levels, cheat-mode practice — MUST go through this pipeline (implemented in `js/levels.js#initializeLessonState`). There is exactly one initializer; parallel implementations are how [TD-2] happened.
+
+## The pipeline
+
+```
+lesson loads            the definition object is selected (levels array,
+                        cheat-mode catalog, later: /content JSON loader)
+        ↓
+lesson validates        shape guards: buffer exists and is a non-empty array;
+                        exactly ONE win-condition property is present
+        ↓
+state initializes       level-scoped state is reset (search, command history,
+                        flags); buffer is written to game state
+        ↓
+cursor created          defaults: cursor {row:0, col:0}, mode NORMAL,
+                        empty command history
+        ↓
+cursor positioned       the lesson's setup() customizes the defaults;
+                        the result is APPLIED to game state and the cursor
+                        is clamped into the buffer (a bad position is
+                        corrected and reported, never silently accepted)
+        ↓
+buffer rendered         the caller triggers updateUI() → renderEditor()
+        ↓
+game starts             input handling resumes; win conditions are
+                        checked after each keystroke
+```
+
+## The consumption invariant
+
+> **Every lesson property must be consumed exactly once during initialization.**
+
+Initialization reads properties through a tracking reader. When it finishes, any property present on the lesson object that was never read is reported immediately (console warning today; CI schema failure once test infra lands). This is the structural fix for the class of bug behind TD-2: configuration data that the engine silently ignores.
+
+Consequences:
+
+- Adding a new field to a lesson without teaching the initializer about it produces an immediate, visible complaint — not a silently dead field.
+- A typo (`taget` instead of `target`) is caught the moment the lesson loads.
+- Zero or multiple win-condition properties (`target`, `targetText`, `targetContent`, `exCommands`) are reported — exactly one is required.
+
+## Known lesson properties
+
+| Property | Consumed at stage | Purpose |
+|---|---|---|
+| `name` | metadata | display + (temporarily) engine special-cases, see TD-7 |
+| `instructions` | metadata | player-facing instructions |
+| `initialContent` | buffer | starting buffer, non-empty `string[]` |
+| `setup(init)` | cursor positioned | customizes `{cursor, mode, commandHistory}` defaults |
+| `target` \| `targetText` \| `targetContent` \| `exCommands` | validates (registered as the objective) | win condition — exactly one |
+
+## Failure policy
+
+Initialization is **corrective, not destructive** (in the spirit of PROJECT_PRINCIPLES.md #8): a lesson with a bad start cursor is clamped and reported; a lesson with a malformed buffer refuses to load (returns `false`) rather than corrupting state. Warnings are loud and specific — they name the lesson and the property.
+
+## Future work (tracked, not implemented)
+
+- **`validateLessonSchema()`** — a real schema validator (zod, Phase 2 content system) run in CI over every content file: cursor within buffer, buffer shape, objective validity, solution replay. The inline guards in `initializeLessonState` are its interim, runtime-side subset. See the TODO in `js/levels.js` and [docs/ContentSystem.md](../ContentSystem.md).
+- **Pure `initializeLesson(level)`** — long-term, initialization becomes a pure function returning a complete state object `{buffer, cursor, objectives, metadata, state}` consumed by the engine, instead of mutating global game state. Recorded in [ADR-0005](../adr/0005-lesson-initialization-pipeline.md); lands with the pure-core refactor (Phase 1).
+
+[TD-2]: ../TechnicalDebt.md

--- a/js/cheat-mode.js
+++ b/js/cheat-mode.js
@@ -5,7 +5,7 @@ import {
     getCommandHistory, setCommandHistory, getCommandLog, setCommandLog, addPracticedCommand
 } from './game-state.js';
 
-import { loadLevel } from './levels.js';
+import { initializeLessonState } from './levels.js';
 import { updateUI } from './event-handlers.js';
 
 // Command catalog with real VIM lessons
@@ -465,26 +465,15 @@ function startCheatPractice(item) {
         commandLog: getCommandLog()
     };
     
-    // Set up the VIM lesson exactly like a real level
-    console.log('🔍 DEBUG: Setting lesson content:', lesson.initialContent);
-    setContent(lesson.initialContent);
-    console.log('🔍 DEBUG: After setContent, current content:', getContent());
-    
-    // Apply lesson setup to game state
-    const gameState = {
-        cursor: getCursor(),
-        mode: getMode(),
-        commandHistory: getCommandHistory(),
-        commandLog: getCommandLog()
-    };
-    lesson.setup(gameState);
-    
-    // Apply the setup changes back to game state
-    setCursor(gameState.cursor);
-    setMode(gameState.mode);
-    setCommandHistory(gameState.commandHistory);
-    setCommandLog(gameState.commandLog);
-    
+    // Set up the VIM lesson through the single initialization pipeline
+    // (docs/architecture/level-lifecycle.md — same path as real levels)
+    if (!initializeLessonState(lesson)) {
+        practiceMode = false;
+        currentPractice = null;
+        originalGameState = null;
+        return;
+    }
+
     // Cache lesson spec for event-driven completion BEFORE updating UI
     currentLessonSpec = lesson;
     

--- a/js/levels.js
+++ b/js/levels.js
@@ -238,32 +238,99 @@ export const levels = [
     }
 ];
 
+// Lesson Initialization Pipeline
+//
+// The ONLY way lesson-shaped content (game levels, cheat-mode practice,
+// future JSON lessons) becomes playable state. The full pipeline is
+// specified in docs/architecture/level-lifecycle.md (ADR-0005); parallel
+// initialization code paths are not accepted.
+//
+// TODO(validateLessonSchema): when the JSON content system lands
+// (docs/ContentSystem.md, Phase 2), replace these runtime guards with a
+// schema validator run in CI over every content file: cursor within buffer,
+// buffer shape, objective validity, solution replay.
+
+// Exactly one of these must be present on every lesson — it is the objective.
+const WIN_CONDITION_PROPS = ['target', 'targetText', 'targetContent', 'exCommands'];
+
+export const initializeLessonState = (lesson) => {
+    // --- lesson validates -------------------------------------------------
+    if (!lesson || !Array.isArray(lesson.initialContent) || lesson.initialContent.length === 0) {
+        console.warn(`VIMMaster: lesson "${lesson?.name ?? '?'}" has no valid initialContent buffer — not loaded`);
+        return false;
+    }
+
+    // Invariant: every lesson property must be consumed exactly once during
+    // initialization. Properties are read through this tracker; anything left
+    // unread at the end is reported immediately (a field the engine ignores
+    // is a silent bug — the root cause of TD-2).
+    const consumed = new Set();
+    const read = (prop) => { consumed.add(prop); return lesson[prop]; };
+
+    // Metadata (rendered by the UI from game state / level lookups)
+    read('name');
+    read('instructions');
+
+    // Objective: register the win condition; exactly one is required.
+    const objectives = WIN_CONDITION_PROPS.filter((prop) => prop in lesson);
+    objectives.forEach(read);
+    if (objectives.length !== 1) {
+        console.warn(`VIMMaster: lesson "${lesson.name}" must define exactly one win condition, found ${objectives.length}${objectives.length ? `: ${objectives.join(', ')}` : ''}`);
+    }
+
+    // --- state initializes ------------------------------------------------
+    const buffer = read('initialContent');
+    setContent(buffer);
+
+    // --- cursor created (defaults) -----------------------------------------
+    const init = {
+        cursor: { row: 0, col: 0 },
+        mode: 'NORMAL',
+        commandHistory: ''
+    };
+
+    // --- cursor positioned --------------------------------------------------
+    // setup() customizes the defaults and its result IS applied — lesson
+    // configuration is never silently ignored.
+    const setup = read('setup');
+    if (typeof setup === 'function') {
+        setup(init);
+    }
+
+    // Clamp the requested cursor into the buffer: a bad position is
+    // corrected and reported, never silently accepted (corrective, not
+    // destructive — see level-lifecycle.md failure policy).
+    const requestedRow = Number.isInteger(init.cursor?.row) ? init.cursor.row : 0;
+    const requestedCol = Number.isInteger(init.cursor?.col) ? init.cursor.col : 0;
+    const row = Math.min(Math.max(requestedRow, 0), buffer.length - 1);
+    const col = Math.min(Math.max(requestedCol, 0), Math.max(0, buffer[row].length - 1));
+    if (row !== requestedRow || col !== requestedCol) {
+        console.warn(`VIMMaster: lesson "${lesson.name}" start cursor {${requestedRow},${requestedCol}} is outside the buffer — clamped to {${row},${col}}`);
+    }
+
+    setCursor({ row, col });
+    setMode(init.mode === 'INSERT' ? 'INSERT' : 'NORMAL');
+    setCommandHistory(typeof init.commandHistory === 'string' ? init.commandHistory : '');
+
+    // --- consumption check --------------------------------------------------
+    const unconsumed = Object.keys(lesson).filter((key) => !consumed.has(key));
+    if (unconsumed.length > 0) {
+        console.warn(`VIMMaster: lesson "${lesson.name}" has properties that were never consumed during initialization: ${unconsumed.join(', ')} — see docs/architecture/level-lifecycle.md`);
+    }
+
+    // buffer rendered / game starts: the caller triggers updateUI()
+    return true;
+};
+
 // Level Management Functions
 export const loadLevel = (levelIndex) => {
     if (levelIndex < 0 || levelIndex >= levels.length) {
         return false;
     }
-    
-    const level = levels[levelIndex];
-    
-    // Update global state variables
+
     setCurrentLevel(levelIndex);
-    setContent(level.initialContent);
-    setCursor({ row: 0, col: 0 });
-    setMode('NORMAL');
-    
-    // Reset level-specific state
     resetLevelState();
-    
-    // Run level setup with minimal state object
-    if (level.setup) {
-        level.setup({ 
-            cursor: getCursor(), 
-            commandHistory: getCommandHistory()
-        });
-    }
-    
-    return true;
+    return initializeLessonState(levels[levelIndex]);
 };
 
 export const getCurrentLevelFromGameState = (gameState) => {


### PR DESCRIPTION
## What does this PR do?

Fixes TD-2 by fixing its architectural cause: the engine allowed lesson configuration data to be silently ignored. Introduces a single initialization pipeline with a consumption invariant, documented as the single source of truth. Fixes TD-2.

> Stacked: #15 (docs) → #16 (TD-1) → this. Retargets automatically as parents merge.

## Type of change

- [x] 🐛 Bug fix

## Root cause

- **Problem:** Every level started at cursor `{0,0}`, even though 12 of 16 levels configure a different start position — lessons like *Insert Mode* dropped the player far from where the exercise begins.
- **Root cause:** `loadLevel()` passed a **copy** of the cursor to `level.setup()` and discarded the result. The deeper cause: nothing anywhere required lesson data to actually be *used* — the engine accepted configuration and was free to ignore it. Cheat-mode had a second, parallel init path (which happened to work), hiding the divergence.
- **Solution:**
  - **One initializer** — `initializeLessonState()` in `levels.js`, now used by both `loadLevel()` and cheat-mode practice (parallel path deleted).
  - **Consumption invariant** — *every lesson property must be consumed exactly once during initialization.* Properties are read through a tracker; unconsumed fields (e.g. a typo'd `taget`) are reported immediately. Exactly one win condition is required and registered.
  - **Corrective failure policy** — out-of-bounds start cursors are clamped **and reported**; missing buffers refuse to load. Config is never silently ignored, state never silently corrupted.
  - **[docs/architecture/level-lifecycle.md](https://github.com/renzorlive/vimmaster/blob/fix/td-2-lesson-initialization/docs/architecture/level-lifecycle.md)** — the load → validate → initialize → position → render → start pipeline as single source of truth, with a `TODO(validateLessonSchema)` for the Phase 2 CI validator.
  - **[ADR-0005](https://github.com/renzorlive/vimmaster/blob/fix/td-2-lesson-initialization/docs/adr/0005-lesson-initialization-pipeline.md)** — records the invariant and the future pure `initializeLesson(level) → {buffer, cursor, objectives, metadata, state}` as the Phase 1 target (noted, not implemented, per approval).
- **Why this happened:** Initialization logic was duplicated (levels vs cheat-mode) and there was no contract between lesson data and the engine — an ignored field produced no signal anywhere.
- **How we prevent this forever:** the consumption invariant makes an ignored field loud the moment a lesson loads; single-initializer rule is review policy (parallel init paths rejected); `validateLessonSchema()` in CI takes over enforcement in Phase 2; the pure `initializeLesson` shape lands with the Phase 1 core.

## How was it verified?

In-browser via static server:
1. **Level 2 (Basic Movement)** now starts at `{1,5}` exactly as configured (was `{0,0}`).
2. **Cheat-mode hjkl practice** initializes through the shared pipeline: correct buffer, cursor `{1,5}`, overlay shown.
3. **Invariant harness** (temporary page, 4 cases): unconsumed property reported ✅ · OOB cursor clamped to `{1,1}` + reported ✅ · missing buffer refused ✅ · conforming lesson loads with **zero** warnings ✅.
4. **End-to-end win:** Insert Mode level completed from its configured start with zero navigation keystrokes → `Learning VIM is awesome!` → “Level 5 Complete!” modal.
5. All 16 levels + cheat lessons load with a clean console (no false-positive invariant warnings).

## Notes for the reviewer

Scope is lesson initialization only. The win-condition *evaluation* special cases (level-name checks, TD-7) are untouched — they are Phase 2 content-system work. `setup()`'s mutable-object convention is kept for compatibility until the pure core (ADR-0005 records the target shape).

- [x] I read CONTRIBUTING.md
- [x] This PR does one thing
- [x] No content-specific logic added to engine code
- [x] Save-data format unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)