### PR TITLE
Fix/td 2 lesson initialization

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,14 @@
 - [ ] 🧹 Refactor / tech debt
 - [ ] 📖 Docs
 
+## Root cause <!-- Required for bug fixes; delete for content/docs/features -->
+
+- **Problem:** <!-- what the user experienced -->
+- **Root cause:** <!-- the actual defect, not the symptom -->
+- **Solution:** <!-- what this PR changes -->
+- **Why this happened:** <!-- the process/design gap that let it in -->
+- **How we prevent this forever:** <!-- test, policy, derived constant, schema… For significant bugs, add a postmortem in docs/postmortems/ -->
+
 ## How was it verified?
 
 <!-- Until automated tests land, describe your manual verification (see the checklist in CONTRIBUTING.md). -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to VIMMaster are documented here.
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: semver, starting with the first tagged release.
+
+## [Unreleased]
+
+### Fixed
+
+- **Saves are no longer destroyed after finishing the game** ([PM-0001](docs/postmortems/PM-0001-save-corruption.md)). The progress validator hardcoded a 15-level range while the game has 16 levels; reaching the final level made the save "invalid", and the loader deleted it on the next visit. All level counts are now derived from `levels.length`.
+- **Invalid saves are repaired, never deleted.** The load path is now: load → validate → repair → otherwise keep the original, write a backup (`vimMasterProgressBackup`), and notify the player. The age-based save rejection (saves older than 1 year were deleted) is removed.
+- **Saved level is actually resumed.** Loading previously applied the saved level to state but then always started the session at level 1.
+- "Clear Progress" (user-initiated) now backs up the save before clearing.
+- The "16 Progressive Levels" text on the page is now computed from the level data.
+
+### Added
+
+- `PROJECT_PRINCIPLES.md` principle #8: *User data is never destroyed automatically* (absolute).
+- `docs/architecture/constants.md`: derivable constants must be derived — policy + review checklist.
+- `docs/postmortems/` with PM-0001.
+- Governance & contributor infrastructure: VISION, PROJECT_PRINCIPLES, NON_GOALS, DECISIONS, PROJECT_STATUS, ROADMAP, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, GitHub issue/PR/RFC templates, ADR system, full `/docs` architecture suite, README banner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: se
 
 ### Fixed
 
+- **Level start positions now apply.** `loadLevel()` discarded the result of each level's `setup()`, so every level started at `{0,0}` despite its configuration. Lessons (game levels and cheat-mode practice) now initialize through a single pipeline ([docs/architecture/level-lifecycle.md](docs/architecture/level-lifecycle.md)) with a consumption invariant: every lesson property must be consumed exactly once during initialization — unconsumed or malformed configuration is reported immediately instead of silently ignored ([ADR-0005](docs/adr/0005-lesson-initialization-pipeline.md)).
 - **Saves are no longer destroyed after finishing the game** ([PM-0001](docs/postmortems/PM-0001-save-corruption.md)). The progress validator hardcoded a 15-level range while the game has 16 levels; reaching the final level made the save "invalid", and the loader deleted it on the next visit. All level counts are now derived from `levels.length`.
 - **Invalid saves are repaired, never deleted.** The load path is now: load → validate → repair → otherwise keep the original, write a backup (`vimMasterProgressBackup`), and notify the player. The age-based save rejection (saves older than 1 year were deleted) is removed.
 - **Saved level is actually resumed.** Loading previously applied the saved level to state but then always started the session at level 1.

--- a/PROJECT_PRINCIPLES.md
+++ b/PROJECT_PRINCIPLES.md
@@ -1,6 +1,6 @@
 # Project Principles
 
-Seven principles. Every PR, feature, and RFC is evaluated against them. When two conflict, the one higher on the list wins.
+Eight principles. Every PR, feature, and RFC is evaluated against them. When two conflict, the one higher on the list wins — except #8, which is absolute and outranks everything.
 
 ---
 
@@ -43,3 +43,9 @@ The page loads in the time it takes to lose a beginner's courage. Every dependen
 ## 7. Community before complexity
 
 Prefer the solution a new contributor can understand. A simpler design that ten people can maintain beats a brilliant one that only its author can.
+
+---
+
+## 8. User data is never destroyed automatically
+
+No code path may delete or discard a user's save because it failed validation, looks old, or has the wrong version. The order is always: **load → validate → repair if possible → otherwise keep the original, create a backup, and notify the user.** Only an explicit, confirmed user action may clear data — and even then, a backup is made first. *(Absolute — outranks every other principle. Origin: [PM-0001](docs/postmortems/PM-0001-save-corruption.md).)*

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -9,7 +9,7 @@
 | **Current version** | pre-1.0 (unversioned; semver starts with the first tagged release in Phase 0.5) |
 | **Current phase** | ✅ Phase 0.5 docs/infra complete → ▶️ **entering Phase 0 — Stabilize** ([ROADMAP.md](ROADMAP.md)) |
 | **Current sprint** | Critical bug fixes, one PR each |
-| **Current focus** | **TD-1: the save-corruption bug** — finishing the final level invalidates and deletes the player's saved progress ([docs/TechnicalDebt.md](docs/TechnicalDebt.md)) |
+| **Current focus** | TD-1 ✅ fixed ([PM-0001](docs/postmortems/PM-0001-save-corruption.md)) — next up: **TD-2** (level start positions ignored) |
 | **Next milestone** | *Stable v0.1*: all Phase 0 boxes checked — 5 bug fixes, debug logging stripped, SEO meta tags |
 | **Release target** | v1.0 after Phases 0–3 (engine rewrite + content system + platform pages) — no date commitment; quality gates over deadlines |
 
@@ -17,7 +17,7 @@
 
 | # | Issue | Severity |
 |---|---|---|
-| TD-1 | Progress save rejected & **deleted** after reaching the final level (off-by-one, 15 vs 16 levels) | 🔴 |
+| TD-1 | ~~Progress save rejected & deleted after the final level~~ ✅ fixed — [PM-0001](docs/postmortems/PM-0001-save-corruption.md) | ✅ |
 | TD-2 | Per-level cursor start positions silently ignored (`setup()` result discarded) | 🔴 |
 | TD-3 | Auto-save on level completion never fires (dead `window` hook) | 🔴 |
 | TD-6 | Duplicate, divergent challenge scoring implementations | 🔴 |

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -9,7 +9,7 @@
 | **Current version** | pre-1.0 (unversioned; semver starts with the first tagged release in Phase 0.5) |
 | **Current phase** | ✅ Phase 0.5 docs/infra complete → ▶️ **entering Phase 0 — Stabilize** ([ROADMAP.md](ROADMAP.md)) |
 | **Current sprint** | Critical bug fixes, one PR each |
-| **Current focus** | TD-1 ✅ fixed ([PM-0001](docs/postmortems/PM-0001-save-corruption.md)) — next up: **TD-2** (level start positions ignored) |
+| **Current focus** | TD-1 ✅ · TD-2 ✅ ([ADR-0005](docs/adr/0005-lesson-initialization-pipeline.md)) — next up: **Phase 0.6 — logger** (replace ~150 debug logs), then testing, then CI |
 | **Next milestone** | *Stable v0.1*: all Phase 0 boxes checked — 5 bug fixes, debug logging stripped, SEO meta tags |
 | **Release target** | v1.0 after Phases 0–3 (engine rewrite + content system + platform pages) — no date commitment; quality gates over deadlines |
 
@@ -18,7 +18,7 @@
 | # | Issue | Severity |
 |---|---|---|
 | TD-1 | ~~Progress save rejected & deleted after the final level~~ ✅ fixed — [PM-0001](docs/postmortems/PM-0001-save-corruption.md) | ✅ |
-| TD-2 | Per-level cursor start positions silently ignored (`setup()` result discarded) | 🔴 |
+| TD-2 | ~~Per-level cursor start positions silently ignored~~ ✅ fixed — [ADR-0005](docs/adr/0005-lesson-initialization-pipeline.md) | ✅ |
 | TD-3 | Auto-save on level completion never fires (dead `window` hook) | 🔴 |
 | TD-6 | Duplicate, divergent challenge scoring implementations | 🔴 |
 | TD-11 | ~150 debug `console.log`s ship to production, some per-keystroke | 🟡 |

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -10,7 +10,7 @@ Each item is small enough to be one reviewable PR unless noted.
 `js/progress-system.js:129` rejects `currentLevel > 14` and `getProgressSummary()` reports `totalLevels: 15`, but `levels.js` defines **16** levels. A player who reaches the last level gets their save rejected on next load — and `autoLoadProgress()` then **deletes** it (`localStorage.removeItem`). Same magic number appears in `sharing-system.js:20`.
 **Fix:** derive from `levels.length` everywhere; never hard-delete on validation failure (keep a backup key).
 
-### TD-2 Level `setup()` never takes effect
+### TD-2 Level `setup()` never takes effect — ✅ FIXED ([ADR-0005](adr/0005-lesson-initialization-pipeline.md), [level-lifecycle.md](architecture/level-lifecycle.md))
 `js/levels.js:259-264` calls `level.setup({ cursor: getCursor(), ... })`. `getCursor()` returns a copy; the setup mutates the copy; nothing is written back. Every level starts at `{row:0, col:0}` even though 12 of 16 levels specify another start position. (Cheat-mode lessons do write the result back — `cheat-mode.js:474-486` — which is why they behave differently.)
 **Fix:** apply `gameState.cursor`/`commandHistory` back via setters after `setup()` runs, mirroring cheat-mode.
 

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -6,7 +6,7 @@ Each item is small enough to be one reviewable PR unless noted.
 
 ## 🔴 Bugs (fix first, no refactoring required)
 
-### TD-1 Progress validation off-by-one destroys saves
+### TD-1 Progress validation off-by-one destroys saves — ✅ FIXED ([PM-0001](postmortems/PM-0001-save-corruption.md))
 `js/progress-system.js:129` rejects `currentLevel > 14` and `getProgressSummary()` reports `totalLevels: 15`, but `levels.js` defines **16** levels. A player who reaches the last level gets their save rejected on next load — and `autoLoadProgress()` then **deletes** it (`localStorage.removeItem`). Same magic number appears in `sharing-system.js:20`.
 **Fix:** derive from `levels.length` everywhere; never hard-delete on validation failure (keep a backup key).
 

--- a/docs/adr/0005-lesson-initialization-pipeline.md
+++ b/docs/adr/0005-lesson-initialization-pipeline.md
@@ -1,0 +1,35 @@
+# ADR-0005: Single lesson-initialization pipeline with a consumption invariant
+
+- **Status:** Accepted
+- **Date:** 2026-07-09
+- **Origin:** TD-2 — lesson `setup()` results were silently discarded; every level started at `{0,0}` regardless of its configuration
+
+## Context
+
+Lesson initialization existed twice: `levels.js#loadLevel` (broken — it passed copies to `setup()` and discarded the result) and `cheat-mode.js#startCheatPractice` (working — it wrote the result back). The engine happily accepted configuration it then ignored; the bug was invisible because nothing checked that lesson data was actually used. With the JSON content system coming (ADR-0003), "engine silently ignores a content field" would become a recurring class of contributor-facing bug: a new field in a lesson file that does nothing, with no error anywhere.
+
+## Decision
+
+1. **One initializer.** All lesson-shaped content (game levels, cheat-mode practice, future JSON lessons) is initialized by a single function, `initializeLessonState(lesson)` in `levels.js`. Parallel init code paths are not accepted in review.
+2. **The consumption invariant:** *every lesson property must be consumed exactly once during initialization.* The initializer reads properties through a tracking reader and reports any property that exists on the lesson but was never read, immediately. Exactly one win-condition property is required and registered as the objective.
+3. **Corrective failure policy:** invalid configuration is repaired-and-reported where safe (out-of-bounds cursor → clamped + warning) and refused where not (missing/empty buffer → lesson does not load). Configuration is never silently ignored and state is never silently corrupted.
+4. **Documented pipeline:** the load → validate → initialize → position → render → start sequence is specified in [docs/architecture/level-lifecycle.md](../architecture/level-lifecycle.md), which is the single source of truth.
+5. **Future direction (recorded now, implemented in Phase 1):** initialization becomes a pure function
+
+   ```ts
+   initializeLesson(level): { buffer, cursor, objectives, metadata, state }
+   ```
+
+   returning a complete state object consumed by the pure engine core, replacing the current mutate-global-state approach and the mutable `setup(gameState)` convention. `validateLessonSchema()` (zod, CI-run) replaces the runtime shape guards when the Phase 2 content system lands.
+
+## Alternatives considered
+
+- **Just write the setup result back** (minimal bug fix) — repairs the symptom, leaves two init paths and no protection against the next ignored field. Rejected: the cause is architectural.
+- **Throw on unconsumed properties** — strictest enforcement, but a typo in one lesson would brick the game for players. Warn loudly at runtime now; *throw in CI* once schema validation exists (best of both).
+- **Freeze/proxy the lesson object to detect reads engine-wide** — heavier machinery for the same guarantee; the tracking reader is ~10 lines and lives where the invariant is defined.
+
+## Trade-offs / consequences
+
+- New lesson fields require touching the initializer (adding them to the known-properties consumption) — intentional friction: a field's meaning must be defined before it can exist.
+- Win-condition properties are *registered* at init and *evaluated* at play time; the invariant covers presence/registration, not evaluation correctness — that's what solution-replay CI (ADR-0003) is for.
+- The `setup()` mutable-object convention survives until Phase 1 solely for compatibility; the pure `initializeLesson` shape above is the committed target.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@ ADRs are **immutable history**: to reverse a decision, write a new ADR that supe
 | [0002](0002-build-tooling-and-ui-framework.md) | Vite + TypeScript build, Preact UI shell, pure-TS Vim core | Proposed |
 | [0003](0003-content-as-data.md) | All content is data, engine knows no content | Accepted |
 | [0004](0004-no-backend-by-default.md) | No backend by default; localStorage + export codes | Accepted |
+| [0005](0005-lesson-initialization-pipeline.md) | Single lesson-initialization pipeline with a consumption invariant | Accepted |

--- a/docs/architecture/constants.md
+++ b/docs/architecture/constants.md
@@ -1,0 +1,60 @@
+# Constants Policy
+
+> **Every constant that can be derived from project data MUST be derived automatically.**
+
+A hardcoded copy of a derivable value is a bug waiting for the data to change. This is not hypothetical: [PM-0001](../postmortems/PM-0001-save-corruption.md) — our first user-facing data-loss bug — was caused by exactly this (`15` written down while `levels.length` grew to 16).
+
+## The rule
+
+❌ Never:
+
+```js
+const TOTAL_LEVELS = 15;
+if (data.currentLevel > 14) { … }
+totalLevels: 15,
+<span>16 Progressive Levels</span>
+```
+
+✔ Always:
+
+```js
+levels.length
+if (data.currentLevel >= levels.length) { … }
+totalLevels: levels.length,
+featureLevelCount.textContent = `${levels.length} Progressive Levels`;
+```
+
+## What this applies to
+
+Any value that has a source of truth elsewhere in the project:
+
+| Value | Derive from |
+|---|---|
+| Number of levels/lessons | `levels.length` (later: the content loader) |
+| Number of challenges | `challenges.length` |
+| Number of achievements/badges | the achievements definition (single source — see TD-12: today there are three divergent badge maps) |
+| Number of commands in the cheat sheet | `commandCatalog` |
+| Number of tracks | the content directory (Phase 2) |
+| Maximum score / points per task | the challenge's own `scoring` data |
+| Valid ranges of any saved field | the data that defines the range (e.g. level index < `levels.length`) |
+| Counts displayed in UI or marketing copy ("16 Progressive Levels") | computed at runtime or at build time — never typed by hand |
+
+If a value is a genuine free-standing decision (autosave interval, undo-stack cap, toast duration), it is allowed — but it must be a **named constant defined once**, not a literal repeated at call sites.
+
+## Review checklist
+
+When reviewing a PR, reject any diff that:
+
+1. introduces a numeric/string literal whose value is derivable from data;
+2. repeats an existing named constant as a literal;
+3. duplicates a definition (badge maps, level lists, key names) instead of importing the existing one.
+
+## Known remaining violations (tracked, out of scope of PM-0001's fix)
+
+These are content-coupling issues scheduled for the Phase 2 content system ([docs/ContentSystem.md](../ContentSystem.md)):
+
+- `event-handlers.js` — badge award threshold `getCurrentLevel() >= 2` (magic level index) and hardcoded search-level name arrays (TD-7);
+- `challenges.js` / `event-handlers.js` — scoring literals (`10`, `100`, time-bonus divisors) pending the `scoring` schema (TD-6);
+- three divergent badge definition maps (TD-12).
+
+When you fix one, remove it from this list.

--- a/docs/architecture/level-lifecycle.md
+++ b/docs/architecture/level-lifecycle.md
@@ -1,0 +1,62 @@
+# Level / Lesson Lifecycle
+
+The single source of truth for how a lesson goes from a definition object to a playable state. Any code that initializes a lesson — `loadLevel()` for game levels, cheat-mode practice — MUST go through this pipeline (implemented in `js/levels.js#initializeLessonState`). There is exactly one initializer; parallel implementations are how [TD-2] happened.
+
+## The pipeline
+
+```
+lesson loads            the definition object is selected (levels array,
+                        cheat-mode catalog, later: /content JSON loader)
+        ↓
+lesson validates        shape guards: buffer exists and is a non-empty array;
+                        exactly ONE win-condition property is present
+        ↓
+state initializes       level-scoped state is reset (search, command history,
+                        flags); buffer is written to game state
+        ↓
+cursor created          defaults: cursor {row:0, col:0}, mode NORMAL,
+                        empty command history
+        ↓
+cursor positioned       the lesson's setup() customizes the defaults;
+                        the result is APPLIED to game state and the cursor
+                        is clamped into the buffer (a bad position is
+                        corrected and reported, never silently accepted)
+        ↓
+buffer rendered         the caller triggers updateUI() → renderEditor()
+        ↓
+game starts             input handling resumes; win conditions are
+                        checked after each keystroke
+```
+
+## The consumption invariant
+
+> **Every lesson property must be consumed exactly once during initialization.**
+
+Initialization reads properties through a tracking reader. When it finishes, any property present on the lesson object that was never read is reported immediately (console warning today; CI schema failure once test infra lands). This is the structural fix for the class of bug behind TD-2: configuration data that the engine silently ignores.
+
+Consequences:
+
+- Adding a new field to a lesson without teaching the initializer about it produces an immediate, visible complaint — not a silently dead field.
+- A typo (`taget` instead of `target`) is caught the moment the lesson loads.
+- Zero or multiple win-condition properties (`target`, `targetText`, `targetContent`, `exCommands`) are reported — exactly one is required.
+
+## Known lesson properties
+
+| Property | Consumed at stage | Purpose |
+|---|---|---|
+| `name` | metadata | display + (temporarily) engine special-cases, see TD-7 |
+| `instructions` | metadata | player-facing instructions |
+| `initialContent` | buffer | starting buffer, non-empty `string[]` |
+| `setup(init)` | cursor positioned | customizes `{cursor, mode, commandHistory}` defaults |
+| `target` \| `targetText` \| `targetContent` \| `exCommands` | validates (registered as the objective) | win condition — exactly one |
+
+## Failure policy
+
+Initialization is **corrective, not destructive** (in the spirit of PROJECT_PRINCIPLES.md #8): a lesson with a bad start cursor is clamped and reported; a lesson with a malformed buffer refuses to load (returns `false`) rather than corrupting state. Warnings are loud and specific — they name the lesson and the property.
+
+## Future work (tracked, not implemented)
+
+- **`validateLessonSchema()`** — a real schema validator (zod, Phase 2 content system) run in CI over every content file: cursor within buffer, buffer shape, objective validity, solution replay. The inline guards in `initializeLessonState` are its interim, runtime-side subset. See the TODO in `js/levels.js` and [docs/ContentSystem.md](../ContentSystem.md).
+- **Pure `initializeLesson(level)`** — long-term, initialization becomes a pure function returning a complete state object `{buffer, cursor, objectives, metadata, state}` consumed by the engine, instead of mutating global game state. Recorded in [ADR-0005](../adr/0005-lesson-initialization-pipeline.md); lands with the pure-core refactor (Phase 1).
+
+[TD-2]: ../TechnicalDebt.md

--- a/docs/postmortems/PM-0001-save-corruption.md
+++ b/docs/postmortems/PM-0001-save-corruption.md
@@ -1,0 +1,46 @@
+# PM-0001: Save corruption — finishing the game destroyed the player's progress
+
+- **Severity:** 🔴 Critical (silent, permanent loss of user data)
+- **Affected:** Every player who reached the final level and later reloaded the page
+- **Status:** Fixed (branch `fix/td-1-save-corruption`)
+
+## Timeline
+
+- **Unknown (pre-2026):** The game ships with 15 levels; `progress-system.js` hardcodes the valid save range as `currentLevel ≤ 14` and `totalLevels: 15` (also copied into `sharing-system.js`).
+- **Later:** A 16th level ("How to Exit") is added to `levels.js`. Nothing forces the hardcoded `14`/`15` to be updated; nothing fails; the numbers silently drift from reality.
+- **From then on:** Any player reaching level 16 (index 15) writes a save that `validateProgressData()` classifies as invalid ("Invalid level number").
+- **On their next page load:** `autoLoadProgress()` sees the "invalid" save and calls `localStorage.removeItem('vimMasterProgress')` — permanently deleting the player's badges, practiced commands, and challenge points. The players most affected were the most engaged ones: those who finished the game.
+- **2026-07-09:** Found during a full-repository architecture review (logged as TD-1 in [docs/TechnicalDebt.md](../TechnicalDebt.md)); fixed with repair-first loading and a full hardcode audit.
+
+A secondary destructive path existed in the same function: any save older than one year was also rejected — and therefore deleted — purely for its age.
+
+## Root cause
+
+Two independent failures compounded:
+
+1. **A derivable value was hardcoded.** The valid level range was written as literals (`14`, `15`) in two files instead of being derived from `levels.length`. When the data changed, the copies didn't.
+2. **Validation failure was treated as license to destroy.** The load path's answer to "I don't recognize this data" was deletion. Validation strictness and data retention were coupled: the stricter the check, the more data got destroyed.
+
+Either failure alone would have been survivable; together, a routine content addition became a data-loss bug.
+
+## Fix
+
+- All level-count literals removed and derived from `levels.length` (`progress-system.js` ×2, `sharing-system.js`, and the "16 Progressive Levels" copy in `index.html`, now populated at runtime).
+- Load path rewritten to: **load → validate → repair → else keep original + backup + notify.** Repair clamps out-of-range levels, defaults missing/mistyped fields, and migrates version mismatches best-effort. Unrepairable saves are left in place and copied to a backup key; the user is told, and nothing is ever deleted.
+- The age-based rejection was removed entirely — old saves are data, not garbage.
+- User-initiated "Clear Progress" now also writes a backup before clearing.
+- Verified in-browser against three scenarios: the exact final-level save (now loads and resumes), a structurally broken save (repaired, original backed up, user notified), and unparseable garbage (kept, backed up, user notified, fresh start).
+
+## Prevention
+
+1. **New absolute principle:** [PROJECT_PRINCIPLES.md #8](../../PROJECT_PRINCIPLES.md) — *User data is never destroyed automatically.* It outranks every other principle.
+2. **Constants policy:** [docs/architecture/constants.md](../architecture/constants.md) — every derivable constant must be derived; reviewers reject literals with a source of truth elsewhere.
+3. **PR template** now requires a Root Cause section (problem, cause, why it happened, how it's prevented forever) for every bug fix.
+4. **Structural (upcoming):** once the test infra lands (Phase 0.5), save/load round-trip tests including the final level become a required CI check; the Phase 2 content system makes level count a loader concern with schema validation.
+
+## Lessons learned
+
+- **Counts drift.** Any literal that mirrors data will eventually lie. Derive or die.
+- **Validation must never be destructive.** Reject-and-delete turns every future validation bug into a data-loss bug. Repair-or-preserve turns them into cosmetic bugs.
+- **The blast radius of "defensive" code needs review too.** Both the range check and the age check were written as protections; both destroyed the thing they protected.
+- **Your best users hit edge cases first.** The trigger condition was *finishing the game* — bugs at the boundaries punish the most engaged players.

--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
             <span>Interactive Learning</span>
             <span>•</span>
             <span>🎯</span>
-            <span>16 Progressive Levels</span>
+            <span id="feature-level-count">Progressive Levels</span>
             <span>•</span>
             <span>⚡</span>
             <span>Speed Challenges</span>

--- a/js/cheat-mode.js
+++ b/js/cheat-mode.js
@@ -5,7 +5,7 @@ import {
     getCommandHistory, setCommandHistory, getCommandLog, setCommandLog, addPracticedCommand
 } from './game-state.js';
 
-import { loadLevel } from './levels.js';
+import { initializeLessonState } from './levels.js';
 import { updateUI } from './event-handlers.js';
 
 // Command catalog with real VIM lessons
@@ -465,26 +465,15 @@ function startCheatPractice(item) {
         commandLog: getCommandLog()
     };
     
-    // Set up the VIM lesson exactly like a real level
-    console.log('🔍 DEBUG: Setting lesson content:', lesson.initialContent);
-    setContent(lesson.initialContent);
-    console.log('🔍 DEBUG: After setContent, current content:', getContent());
-    
-    // Apply lesson setup to game state
-    const gameState = {
-        cursor: getCursor(),
-        mode: getMode(),
-        commandHistory: getCommandHistory(),
-        commandLog: getCommandLog()
-    };
-    lesson.setup(gameState);
-    
-    // Apply the setup changes back to game state
-    setCursor(gameState.cursor);
-    setMode(gameState.mode);
-    setCommandHistory(gameState.commandHistory);
-    setCommandLog(gameState.commandLog);
-    
+    // Set up the VIM lesson through the single initialization pipeline
+    // (docs/architecture/level-lifecycle.md — same path as real levels)
+    if (!initializeLessonState(lesson)) {
+        practiceMode = false;
+        currentPractice = null;
+        originalGameState = null;
+        return;
+    }
+
     // Cache lesson spec for event-driven completion BEFORE updating UI
     currentLessonSpec = lesson;
     

--- a/js/levels.js
+++ b/js/levels.js
@@ -238,32 +238,99 @@ export const levels = [
     }
 ];
 
+// Lesson Initialization Pipeline
+//
+// The ONLY way lesson-shaped content (game levels, cheat-mode practice,
+// future JSON lessons) becomes playable state. The full pipeline is
+// specified in docs/architecture/level-lifecycle.md (ADR-0005); parallel
+// initialization code paths are not accepted.
+//
+// TODO(validateLessonSchema): when the JSON content system lands
+// (docs/ContentSystem.md, Phase 2), replace these runtime guards with a
+// schema validator run in CI over every content file: cursor within buffer,
+// buffer shape, objective validity, solution replay.
+
+// Exactly one of these must be present on every lesson — it is the objective.
+const WIN_CONDITION_PROPS = ['target', 'targetText', 'targetContent', 'exCommands'];
+
+export const initializeLessonState = (lesson) => {
+    // --- lesson validates -------------------------------------------------
+    if (!lesson || !Array.isArray(lesson.initialContent) || lesson.initialContent.length === 0) {
+        console.warn(`VIMMaster: lesson "${lesson?.name ?? '?'}" has no valid initialContent buffer — not loaded`);
+        return false;
+    }
+
+    // Invariant: every lesson property must be consumed exactly once during
+    // initialization. Properties are read through this tracker; anything left
+    // unread at the end is reported immediately (a field the engine ignores
+    // is a silent bug — the root cause of TD-2).
+    const consumed = new Set();
+    const read = (prop) => { consumed.add(prop); return lesson[prop]; };
+
+    // Metadata (rendered by the UI from game state / level lookups)
+    read('name');
+    read('instructions');
+
+    // Objective: register the win condition; exactly one is required.
+    const objectives = WIN_CONDITION_PROPS.filter((prop) => prop in lesson);
+    objectives.forEach(read);
+    if (objectives.length !== 1) {
+        console.warn(`VIMMaster: lesson "${lesson.name}" must define exactly one win condition, found ${objectives.length}${objectives.length ? `: ${objectives.join(', ')}` : ''}`);
+    }
+
+    // --- state initializes ------------------------------------------------
+    const buffer = read('initialContent');
+    setContent(buffer);
+
+    // --- cursor created (defaults) -----------------------------------------
+    const init = {
+        cursor: { row: 0, col: 0 },
+        mode: 'NORMAL',
+        commandHistory: ''
+    };
+
+    // --- cursor positioned --------------------------------------------------
+    // setup() customizes the defaults and its result IS applied — lesson
+    // configuration is never silently ignored.
+    const setup = read('setup');
+    if (typeof setup === 'function') {
+        setup(init);
+    }
+
+    // Clamp the requested cursor into the buffer: a bad position is
+    // corrected and reported, never silently accepted (corrective, not
+    // destructive — see level-lifecycle.md failure policy).
+    const requestedRow = Number.isInteger(init.cursor?.row) ? init.cursor.row : 0;
+    const requestedCol = Number.isInteger(init.cursor?.col) ? init.cursor.col : 0;
+    const row = Math.min(Math.max(requestedRow, 0), buffer.length - 1);
+    const col = Math.min(Math.max(requestedCol, 0), Math.max(0, buffer[row].length - 1));
+    if (row !== requestedRow || col !== requestedCol) {
+        console.warn(`VIMMaster: lesson "${lesson.name}" start cursor {${requestedRow},${requestedCol}} is outside the buffer — clamped to {${row},${col}}`);
+    }
+
+    setCursor({ row, col });
+    setMode(init.mode === 'INSERT' ? 'INSERT' : 'NORMAL');
+    setCommandHistory(typeof init.commandHistory === 'string' ? init.commandHistory : '');
+
+    // --- consumption check --------------------------------------------------
+    const unconsumed = Object.keys(lesson).filter((key) => !consumed.has(key));
+    if (unconsumed.length > 0) {
+        console.warn(`VIMMaster: lesson "${lesson.name}" has properties that were never consumed during initialization: ${unconsumed.join(', ')} — see docs/architecture/level-lifecycle.md`);
+    }
+
+    // buffer rendered / game starts: the caller triggers updateUI()
+    return true;
+};
+
 // Level Management Functions
 export const loadLevel = (levelIndex) => {
     if (levelIndex < 0 || levelIndex >= levels.length) {
         return false;
     }
-    
-    const level = levels[levelIndex];
-    
-    // Update global state variables
+
     setCurrentLevel(levelIndex);
-    setContent(level.initialContent);
-    setCursor({ row: 0, col: 0 });
-    setMode('NORMAL');
-    
-    // Reset level-specific state
     resetLevelState();
-    
-    // Run level setup with minimal state object
-    if (level.setup) {
-        level.setup({ 
-            cursor: getCursor(), 
-            commandHistory: getCommandHistory()
-        });
-    }
-    
-    return true;
+    return initializeLessonState(levels[levelIndex]);
 };
 
 export const getCurrentLevelFromGameState = (gameState) => {

--- a/js/main.js
+++ b/js/main.js
@@ -46,14 +46,21 @@ function initializeGame() {
     // Initialize DOM references
     initializeDOMReferences();
     
-    // Auto-load progress if available
-    const progressLoaded = autoLoadProgress();
-    if (progressLoaded) {
-        console.log('Progress loaded from localStorage');
+    // Auto-load progress if available. Invalid saves are repaired when
+    // possible and backed up otherwise — never silently deleted (PM-0001).
+    const progressResult = autoLoadProgress();
+    if (progressResult.message) {
+        showProgressMessage(progressResult.message, progressResult.loaded ? 'info' : 'error');
     }
-    
-    // Load first level
-    loadLevel(0);
+
+    // Resume at the saved level, or start at the first level
+    loadLevel(progressResult.loaded ? getCurrentLevel() : 0);
+
+    // Level count in the feature list is derived, never hardcoded
+    const featureLevelCount = document.getElementById('feature-level-count');
+    if (featureLevelCount) {
+        featureLevelCount.textContent = `${levels.length} Progressive Levels`;
+    }
     
     // Initial UI update
     updateUI();

--- a/js/progress-system.js
+++ b/js/progress-system.js
@@ -1,15 +1,19 @@
 // VIM Master Game - Progress Save/Load System
 
-import { 
+import {
     getBadges, getPracticedCommands, getCurrentLevel, getChallengeMode, getChallengeScoreValue,
     setBadges, setPracticedCommands, setCurrentLevel, setChallengeMode, setChallengeScoreValue
 } from './game-state.js';
+
+import { levels } from './levels.js';
 
 // Progress System Class
 class ProgressSystem {
     constructor() {
         this.version = '1.0';
         this.exportPrefix = 'VIM_MASTER_PROGRESS_';
+        this.storageKey = 'vimMasterProgress';
+        this.backupKey = 'vimMasterProgressBackup';
     }
 
     /**
@@ -125,18 +129,63 @@ class ProgressSystem {
             return { valid: false, message: 'Invalid data types in progress data' };
         }
 
-        // Check level range
-        if (data.currentLevel < 0 || data.currentLevel > 14) {
+        // Check level range (always derived from the levels data — never hardcoded,
+        // see docs/architecture/constants.md)
+        if (!Number.isInteger(data.currentLevel) || data.currentLevel < 0 || data.currentLevel >= levels.length) {
             return { valid: false, message: 'Invalid level number in progress data' };
         }
 
-        // Check timestamp (reject very old data)
-        const maxAge = 365 * 24 * 60 * 60 * 1000; // 1 year
-        if (Date.now() - data.timestamp > maxAge) {
-            return { valid: false, message: 'Progress data is too old and may be incompatible' };
+        return { valid: true };
+    }
+
+    /**
+     * Attempt to repair invalid progress data instead of rejecting it.
+     * User data is never destroyed automatically (PROJECT_PRINCIPLES.md #8).
+     * @param {Object} data - Possibly-invalid progress data
+     * @returns {Object|null} A valid progress object, or null if unrepairable
+     */
+    repairProgressData(data) {
+        if (typeof data !== 'object' || data === null) {
+            return null;
         }
 
-        return { valid: true };
+        const repaired = { ...data };
+
+        // Best-effort migration: normalize to the current version after
+        // defaulting any fields that version didn't have
+        repaired.version = this.version;
+        if (typeof repaired.timestamp !== 'number') repaired.timestamp = Date.now();
+        if (!Array.isArray(repaired.badges)) repaired.badges = [];
+        if (!Array.isArray(repaired.practicedCommands)) repaired.practicedCommands = [];
+        if (typeof repaired.challengeMode !== 'boolean') repaired.challengeMode = false;
+        if (typeof repaired.challengePoints !== 'number' || !Number.isFinite(repaired.challengePoints)) {
+            repaired.challengePoints = 0;
+        }
+
+        // Clamp the level into the valid range instead of rejecting it
+        const level = Number(repaired.currentLevel);
+        repaired.currentLevel = Number.isFinite(level)
+            ? Math.min(Math.max(Math.trunc(level), 0), levels.length - 1)
+            : 0;
+
+        return this.validateProgressData(repaired).valid ? repaired : null;
+    }
+
+    /**
+     * Preserve the original (raw) save before it can be overwritten.
+     * @param {string} raw - The raw string found in storage
+     * @param {string} reason - Why the backup was made
+     */
+    backupProgress(raw, reason) {
+        try {
+            localStorage.setItem(this.backupKey, JSON.stringify({
+                backedUpAt: Date.now(),
+                reason,
+                raw
+            }));
+        } catch (error) {
+            console.warn('Failed to back up progress data:', error);
+        }
     }
 
     /**
@@ -171,7 +220,7 @@ class ProgressSystem {
      */
     saveToLocalStorage(data) {
         try {
-            localStorage.setItem('vimMasterProgress', JSON.stringify(data));
+            localStorage.setItem(this.storageKey, JSON.stringify(data));
         } catch (error) {
             console.warn('Failed to save progress to localStorage:', error);
         }
@@ -183,7 +232,7 @@ class ProgressSystem {
      */
     loadFromLocalStorage() {
         try {
-            const stored = localStorage.getItem('vimMasterProgress');
+            const stored = localStorage.getItem(this.storageKey);
             if (stored) {
                 return JSON.parse(stored);
             }
@@ -194,24 +243,61 @@ class ProgressSystem {
     }
 
     /**
-     * Auto-load progress on game start
+     * Auto-load progress on game start.
+     *
+     * Load → validate → if invalid, try repair → if repaired, continue;
+     * otherwise keep the original save, create a backup, and notify the user.
+     * A save is NEVER deleted here, no matter how corrupted (see PM-0001).
+     *
+     * @returns {{loaded: boolean, repaired: boolean, message: string|null}}
      */
     autoLoadProgress() {
-        const storedProgress = this.loadFromLocalStorage();
-        if (storedProgress) {
-            console.log('🔍 DEBUG: autoLoadProgress - stored progress:', storedProgress);
-            const validation = this.validateProgressData(storedProgress);
+        let raw = null;
+        try {
+            raw = localStorage.getItem(this.storageKey);
+        } catch (error) {
+            console.warn('Failed to access saved progress:', error);
+            return { loaded: false, repaired: false, message: null };
+        }
+
+        if (!raw) {
+            return { loaded: false, repaired: false, message: null };
+        }
+
+        let stored = null;
+        try {
+            stored = JSON.parse(raw);
+        } catch (error) {
+            console.warn('Saved progress is not valid JSON:', error);
+        }
+
+        if (stored) {
+            const validation = this.validateProgressData(stored);
             if (validation.valid) {
-                console.log('🔍 DEBUG: autoLoadProgress - applying progress data');
-                this.applyProgressData(storedProgress);
-                return true;
-            } else {
-                console.log('🔍 DEBUG: autoLoadProgress - validation failed:', validation.message);
-                // Clear invalid stored data
-                localStorage.removeItem('vimMasterProgress');
+                this.applyProgressData(stored);
+                return { loaded: true, repaired: false, message: null };
+            }
+
+            const repaired = this.repairProgressData(stored);
+            if (repaired) {
+                this.backupProgress(raw, `repaired: ${validation.message}`);
+                this.applyProgressData(repaired);
+                this.saveToLocalStorage(repaired);
+                return {
+                    loaded: true,
+                    repaired: true,
+                    message: 'Your saved progress was automatically repaired. A backup of the original was kept.'
+                };
             }
         }
-        return false;
+
+        // Unrepairable: keep the original save untouched, back it up, tell the user.
+        this.backupProgress(raw, 'unrepairable');
+        return {
+            loaded: false,
+            repaired: false,
+            message: 'Your saved progress could not be read. It was NOT deleted — a backup was kept in your browser.'
+        };
     }
 
     /**
@@ -239,11 +325,17 @@ class ProgressSystem {
     }
 
     /**
-     * Clear all saved progress
+     * Clear all saved progress. This is only ever called from an explicit,
+     * user-confirmed action — even then, the save is backed up first
+     * (user data is never destroyed automatically, PROJECT_PRINCIPLES.md #8).
      */
     clearProgress() {
         try {
-            localStorage.removeItem('vimMasterProgress');
+            const raw = localStorage.getItem(this.storageKey);
+            if (raw) {
+                this.backupProgress(raw, 'user-initiated clear');
+            }
+            localStorage.removeItem(this.storageKey);
             
             // Clear the game state using statically imported functions
             try {
@@ -284,7 +376,7 @@ class ProgressSystem {
         
         const result = {
             currentLevel: getCurrentLevel(),
-            totalLevels: 15,
+            totalLevels: levels.length,
             badgesEarned: getBadges().size,
             commandsPracticed: getPracticedCommands().size,
             challengePoints: safeChallengePoints,
@@ -301,7 +393,7 @@ class ProgressSystem {
      */
     getLastSavedTime() {
         try {
-            const stored = localStorage.getItem('vimMasterProgress');
+            const stored = localStorage.getItem(this.storageKey);
             if (stored) {
                 const data = JSON.parse(stored);
                 return new Date(data.timestamp).toLocaleString();

--- a/js/sharing-system.js
+++ b/js/sharing-system.js
@@ -5,6 +5,7 @@ import {
 } from './game-state.js';
 
 import { exportProgress } from './progress-system.js';
+import { levels } from './levels.js';
 
 class VimMasterSharingSystem {
     constructor() {
@@ -17,7 +18,7 @@ class VimMasterSharingSystem {
     getGameData() {
         return {
             level: getCurrentLevel() + 1,
-            totalLevels: 15, // Total available levels
+            totalLevels: levels.length, // Always derived, never hardcoded (docs/architecture/constants.md)
             levelsCompleted: getCurrentLevel() + 1, // Actual levels completed
             badges: Array.from(getBadges()),
             commandsPracticed: getPracticedCommands().size,


### PR DESCRIPTION
<!-- Thank you for contributing to VIMMaster! Small, single-concern PRs get reviewed fastest. -->

## What does this PR do?

<!-- One or two sentences. Link the issue: Fixes #123 -->

## Type of change

- [x] 🐛 Bug fix
- [ ] 📚 Content (lesson / challenge / achievement / translation)
- [ ] ✨ Feature
- [ ] 🧹 Refactor / tech debt
- [ ] 📖 Docs

## How was it verified?

<!-- Until automated tests land, describe your manual verification (see the checklist in CONTRIBUTING.md). -->

- [x] Ran the game locally via a static server and exercised the affected flow end-to-end
- [x] Console is free of new errors
- [x] For lesson changes: played the lesson and **won** it
- [x] For engine changes: ran the manual test checklist (levels 1/2/5/6, one challenge, one cheat-mode practice, export/import)

## Screenshots / recording

<!-- Required for UI changes. Delete this section otherwise. -->

## Notes for the reviewer

<!-- Anything unusual: trade-offs, follow-ups, parts you're unsure about. Honesty speeds up review. -->

---

- [x] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)
- [x] This PR does **one** thing
- [x] No content-specific logic added to engine code
- [x] Save-data format unchanged (or labeled `breaking-save` with a migration)
