### PR TITLE
fix: save progress on level completion; single challenge-scoring source (PR26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: se
 
 ## [Unreleased]
 
+### Fixed (PR26 — completion auto-save & challenge scoring)
+- **Progress is saved the moment a level is won** (TD-3). The intended on-completion save was a dead `window.checkWinCondition` wrapper that never ran; wins relied on the 30-second interval save and could be lost by closing the tab. The save now lives inside the win path itself. Regression-tested.
+- **Challenge task scoring has a single source of truth** (TD-6): dead `endChallenge`/`checkChallengeTask` exports (carrying a divergent 100-points formula players never experienced) are deleted; the live formula (10 + 1 point per 10s remaining) lives only in `challenges.js#calculateTaskPoints`, unit-tested, with dead imports cleaned from three modules.
+
 ### Fixed (PR25 — stale-state normal mode)
 - **Numeric counts now work as promised.** `2x` deleted a single character (counted edits looped over a stale buffer snapshot — TD-4b), and `2dd`/`2dw` never worked at all (the operator's first key wiped the pending count). Counts survive multi-key commands and each loop iteration reads fresh state. 8 new regression tests.
 - **`0` no longer silently fails after `j` onto a shorter line** (TD-4): the end-of-handler bounds clamp evaluated the cursor captured at handler entry and overwrote valid motions; it now clamps fresh state, and `j` onto a shorter line clamps the column into the line.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -9,7 +9,7 @@
 | **Current version** | v3.0.0 — Community Alpha (see [CHANGELOG.md](CHANGELOG.md)) |
 | **Current phase** | ✅ Phase 0 (bugs) · ✅ tooling/tests (unit + contract + golden + regression) · ✅ **content extraction** (35 JSON lessons in `/content/lessons`) → ▶️ Community Alpha hardening ([ROADMAP.md](ROADMAP.md)) |
 | **Current sprint** | PR24: every lesson provably solvable — `solution` in all 35 lessons, Golden Suite auto-verifies each (35/35), L007 promoted to ERROR |
-| **Current focus** | Community Alpha release readiness; next candidates: TD-3/TD-6 bug fixes, TD-4/TD-4b engine fixes with regression tests, lint-warning burn-down (~192) |
+| **Current focus** | **All 🔴 Phase-0 bugs closed** (TD-1..TD-4b, TD-6 — each regression-tested). Next: lint-warning burn-down (~186), debug-log strip (TD-11), Community Alpha release checklist |
 | **Next milestone** | Community Alpha announcement once the release checklist in QUALITY.md is green |
 | **Release target** | v1.0 after the pure-core engine rewrite + platform pages — no date commitment; quality gates over deadlines |
 
@@ -19,10 +19,10 @@
 |---|---|---|
 | TD-1 | ~~Progress save rejected & deleted after the final level~~ ✅ fixed — [PM-0001](docs/postmortems/PM-0001-save-corruption.md), regression-tested | ✅ |
 | TD-2 | ~~Per-level cursor start positions silently ignored~~ ✅ fixed — [ADR-0005](docs/adr/0005-lesson-initialization-pipeline.md), regression-tested | ✅ |
-| TD-3 | Auto-save on level completion never fires (dead `window` hook) | 🔴 |
+| TD-3 | ~~Auto-save on level completion never fires~~ ✅ fixed — PR26, regression-tested | ✅ |
 | TD-4 | ~~Stale cursor clamp (`0` failed past EOL after `j`)~~ ✅ fixed — PR25, regression-tested | ✅ |
 | TD-4b | ~~Counted edits stale/broken (`2x`→1 char; `2dd`/`2dw` never worked)~~ ✅ fixed — PR25, regression-tested | ✅ |
-| TD-6 | Duplicate, divergent challenge scoring implementations | 🔴 |
+| TD-6 | ~~Duplicate, divergent challenge scoring~~ ✅ fixed — PR26, single source + unit tests | ✅ |
 | TD-11 | Debug `console.log`s ship to production | 🟡 |
 
 Full register with file/line references: [docs/TechnicalDebt.md](docs/TechnicalDebt.md).

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -14,7 +14,7 @@ Each item is small enough to be one reviewable PR unless noted.
 `js/levels.js:259-264` calls `level.setup({ cursor: getCursor(), ... })`. `getCursor()` returns a copy; the setup mutates the copy; nothing is written back. Every level starts at `{row:0, col:0}` even though 12 of 16 levels specify another start position. (Cheat-mode lessons do write the result back — `cheat-mode.js:474-486` — which is why they behave differently.)
 **Fix:** apply `gameState.cursor`/`commandHistory` back via setters after `setup()` runs, mirroring cheat-mode.
 
-### TD-3 Auto-save-on-completion never fires
+### TD-3 Auto-save-on-completion never fires — ✅ FIXED (PR26, regression-tested)
 `js/main.js:463-476` wraps `window.checkWinCondition`, but `checkWinCondition` is an ES-module export that is never assigned to `window`. The wrapper is dead code; only the 30-second interval save works.
 **Fix:** call `autoSaveProgress()` from the actual win path in `checkWinCondition()`.
 
@@ -29,7 +29,7 @@ Found by the Golden Suite (PR24): the count loops for `x` (and `dw`) re-read `co
 ### TD-5 `0` is unreachable as a motion
 `vim-commands.js:64-70` routes `0` into the count buffer unless the buffer is empty, then line 239 also treats `0` as "go to line start" — but only when the count buffer is empty, and `$`'s handler at line 240 runs even when `$` was typed during a pending count. Behavior around `10j`, `0`, `d0` is inconsistent. Verify with tests once the core is testable.
 
-### TD-6 Duplicate, divergent challenge logic
+### TD-6 Duplicate, divergent challenge logic — ✅ FIXED (PR26: dead `endChallenge`/`checkChallengeTask` deleted; scoring lives only in `challenges.js#calculateTaskPoints`, unit-tested)
 `challenges.js#checkChallengeTask` and `#endChallenge` are never called; scoring was re-implemented in `event-handlers.js#checkWinCondition` with different point values (10 + time/10 vs 100 + timeBonus). One source of truth must win.
 **Fix:** delete the dead functions or (better) move scoring back into `challenges.js` and call it.
 

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -191,63 +191,21 @@ export const startChallenge = (gameState, challengeIndex = null) => {
     return gameState.currentChallenge;
 };
 
-export const endChallenge = (gameState, success) => {
-    if (gameState.challengeTimerInterval) {
-        clearInterval(gameState.challengeTimerInterval);
-        gameState.challengeTimerInterval = null;
-    }
-    
-    let result = null;
-    if (success) {
-        const elapsed = Math.floor((Date.now() - gameState.challengeStartTime) / 1000);
-        const finalScore = gameState.challengeScoreValue + Math.max(0, gameState.currentChallenge.timeLimit - elapsed) * 10;
-        result = {
-            success: true,
-            score: finalScore,
-            time: elapsed
-        };
-    } else {
-        result = {
-            success: false,
-            score: gameState.challengeScoreValue,
-            time: Math.floor((Date.now() - gameState.challengeStartTime) / 1000)
-        };
-    }
-    
-    // Reset challenge state
-    gameState.resetChallengeState();
-    
-    return result;
-};
+// NOTE (TD-6): the former endChallenge/checkChallengeTask exports were dead
+// code carrying a *divergent* scoring formula (100 + full time bonus) that
+// was never what players experienced. Deleted; the single source of truth
+// for task scoring is calculateTaskPoints below.
 
-export const checkChallengeTask = (gameState) => {
-    if (!gameState.currentChallenge || gameState.currentTaskIndex >= gameState.currentChallenge.tasks.length) {
-        return false;
-    }
-    
-    const task = gameState.currentChallenge.tasks[gameState.currentTaskIndex];
-    if (task.validation(gameState)) {
-        // Task completed
-        gameState.challengeProgressValue++;
-        
-        // Calculate score based on time
-        const elapsed = Math.floor((Date.now() - gameState.challengeStartTime) / 1000);
-        const timeBonus = Math.max(0, gameState.currentChallenge.timeLimit - elapsed);
-        const taskScore = 100 + timeBonus;
-        gameState.challengeScoreValue += taskScore;
-        
-        gameState.currentTaskIndex++;
-        
-        if (gameState.currentTaskIndex >= gameState.currentChallenge.tasks.length) {
-            // All tasks completed
-            return { completed: true, taskCompleted: true };
-        } else {
-            // Show next task
-            return { completed: false, taskCompleted: true, nextTask: gameState.currentChallenge.tasks[gameState.currentTaskIndex] };
-        }
-    }
-    
-    return { completed: false, taskCompleted: false };
+/**
+ * Points awarded for completing a challenge task: base 10 plus 1 point per
+ * 10 seconds remaining. Single source of truth for task scoring (TD-6).
+ */
+export const calculateTaskPoints = (challenge, challengeStartTime) => {
+    const timeRemaining = getChallengeTimeRemaining({
+        currentChallenge: challenge,
+        challengeStartTime
+    });
+    return 10 + Math.max(0, Math.floor(timeRemaining / 10));
 };
 
 export const getCurrentTask = (gameState) => {

--- a/js/event-handlers.js
+++ b/js/event-handlers.js
@@ -20,7 +20,7 @@ import {
 
 import { levels, loadLevel, getCurrentLevelFromGameState, getLevelCount, isLastLevel } from './levels.js';
 import { isInPracticeMode, getCurrentLessonSpec } from './cheat-mode.js';
-import { challenges, startChallenge, endChallenge, checkChallengeTask, getChallengeTimeRemaining, getChallengeProgress } from './challenges.js';
+import { challenges, startChallenge, getChallengeTimeRemaining, calculateTaskPoints } from './challenges.js';
 import { handleNormalMode, handleInsertMode, handleSearchMode } from './vim-commands.js';
 import { 
     renderEditor, updateStatusBar, updateInstructions, updateLevelIndicator, 
@@ -60,12 +60,8 @@ export function checkWinCondition() {
             if (validationResult) {
                 console.log('🔍 Challenge task completed!');
                 
-                                 // Award points for completing task
-                 const timeBonus = Math.max(0, Math.floor(getChallengeTimeRemaining({
-                     currentChallenge: challenge,
-                     challengeStartTime: getChallengeStartTime()
-                 }) / 10)); // 1 point per 10 seconds remaining
-                 const taskPoints = 10 + timeBonus;
+                 // Award points via the single scoring source of truth (TD-6)
+                 const taskPoints = calculateTaskPoints(challenge, getChallengeStartTime());
                  setChallengeScoreValue(getChallengeScoreValue() + taskPoints);
                  
                  console.log('🔍 Task completed! Points awarded:', taskPoints, 'Total score:', getChallengeScoreValue());
@@ -180,7 +176,19 @@ export function checkWinCondition() {
             
             setXp(getXp() + earnedXp);
             setCombo(getCombo() + 1);
-            
+
+            // Persist progress at the moment of completion (TD-3): the dead
+            // window.checkWinCondition wrapper never ran, so wins relied on
+            // the 30s interval save and could be lost on a quick tab close.
+            try {
+                autoSaveProgress();
+                if (typeof window.updateProgressSummary === 'function') {
+                    window.updateProgressSummary();
+                }
+            } catch (error) {
+                console.warn('Failed to auto-save progress on level completion:', error);
+            }
+
             // Check if this is the final level
             if (getCurrentLevel() === levels.length - 1) {
                 // Final level completed - show celebration directly

--- a/js/main.js
+++ b/js/main.js
@@ -19,7 +19,7 @@ import {
 } from './game-state.js';
 
 import { levels, loadLevel, getLevelCount, isLastLevel } from './levels.js';
-import { challenges, startChallenge, endChallenge, checkChallengeTask } from './challenges.js';
+import { challenges, startChallenge } from './challenges.js';
 import { handleNormalMode, handleInsertMode, handleSearchMode } from './vim-commands.js';
 import { 
     initializeDOMReferences, renderEditor, updateStatusBar, updateInstructions, 
@@ -470,22 +470,10 @@ function setupAutoSave() {
         updateProgressSummary();
     }, 30000);
     
-    // Auto-save on level completion
-    const originalCheckWinCondition = window.checkWinCondition;
-    if (originalCheckWinCondition) {
-        window.checkWinCondition = function() {
-            const result = originalCheckWinCondition();
-            if (result) {
-                // Progress was made, auto-save
-                setTimeout(() => {
-                    autoSaveProgress();
-                    updateProgressSummary();
-                }, 1000);
-            }
-            return result;
-        };
-    }
-    
+    // Auto-save on level completion happens inside checkWinCondition's win
+    // path (event-handlers.js) — a window.checkWinCondition wrapper here was
+    // dead code because the function was never assigned to window (TD-3).
+
     // Update progress summary more frequently for real-time updates
     setInterval(() => {
         updateProgressSummary();

--- a/js/vim-commands.js
+++ b/js/vim-commands.js
@@ -16,7 +16,6 @@ import {
 } from './game-state.js';
 
 import { levels } from './levels.js';
-import { checkChallengeTask } from './challenges.js';
 import { updateStatusBar } from './ui-components.js';
 
 // Utility function for repeating actions

--- a/tests/regressions/autosave-on-completion.regression.test.js
+++ b/tests/regressions/autosave-on-completion.regression.test.js
@@ -1,0 +1,70 @@
+/**
+ * Regression ID: TD-3
+ *
+ * Issue: Auto-save on level completion never fired.
+ *
+ * Original Cause: main.js wrapped `window.checkWinCondition` to save after a
+ * win, but `checkWinCondition` is an ES-module export that was never assigned
+ * to `window` — the wrapper was dead code. Wins were persisted only by the
+ * 30-second interval save.
+ *
+ * User Impact: Completing a level and closing the tab within the interval
+ * window lost the completion (XP, badges, level) silently.
+ *
+ * Test Strategy: put the engine in a winning state for a real lesson, call
+ * checkWinCondition(), advance the completion timers, and assert the save
+ * landed in storage — without any interval timer involved.
+ *
+ * Never Break Again: the save lives inside checkWinCondition's win path
+ * itself (event-handlers.js); the dead window wrapper was removed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupMockStorage } from '../helpers/mock-storage.js';
+import { checkWinCondition } from '../../js/event-handlers.js';
+import { levels } from '../../js/levels.js';
+import {
+    resetGameState, setContent, setCursor, setMode, setCurrentLevel,
+    setChallengeMode
+} from '../../js/game-state.js';
+
+describe('Regression: TD-3 auto-save on level completion', () => {
+    let mockStorage;
+    let originalConsoleLog;
+
+    beforeEach(() => {
+        mockStorage = setupMockStorage();
+        vi.useFakeTimers();
+        originalConsoleLog = console.log;
+        console.log = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        console.log = originalConsoleLog;
+        vi.restoreAllMocks();
+    });
+
+    it('persists progress the moment a level is won, without interval timers', () => {
+        // Arrange: a cursor-target lesson driven into its winning state
+        const index = levels.findIndex((l) => l.target);
+        const lesson = levels[index];
+        resetGameState();
+        setChallengeMode(false);
+        setCurrentLevel(index);
+        setContent(lesson.initialContent);
+        setMode('NORMAL');
+        setCursor({ row: lesson.target.row, col: lesson.target.col });
+
+        expect(mockStorage.getItem('vimMasterProgress')).toBeNull();
+
+        // Act: evaluate the win and run the completion timers (flash + modal)
+        checkWinCondition();
+        vi.runAllTimers();
+
+        // Assert: the save exists and records the completed level
+        const raw = mockStorage.getItem('vimMasterProgress');
+        expect(raw).not.toBeNull();
+        expect(JSON.parse(raw).currentLevel).toBe(index);
+    });
+});

--- a/tests/unit/challenges.test.js
+++ b/tests/unit/challenges.test.js
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for challenge task scoring — the single source of truth
+ * introduced by TD-6 (the former dead endChallenge/checkChallengeTask
+ * exports carried a divergent formula that players never experienced).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { calculateTaskPoints, challenges } from '../../js/challenges.js';
+
+describe('calculateTaskPoints (TD-6 single scoring source)', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('awards base 10 plus 1 point per 10 seconds remaining', () => {
+        vi.useFakeTimers();
+        const challenge = { timeLimit: 90 };
+        const startTime = Date.now();
+
+        // Immediately: 90s remaining → 10 + 9
+        expect(calculateTaskPoints(challenge, startTime)).toBe(19);
+
+        // After 45s: 45s remaining → 10 + 4
+        vi.advanceTimersByTime(45_000);
+        expect(calculateTaskPoints(challenge, startTime)).toBe(14);
+    });
+
+    it('never awards less than the base points, even after time runs out', () => {
+        vi.useFakeTimers();
+        const challenge = { timeLimit: 30 };
+        const startTime = Date.now();
+        vi.advanceTimersByTime(120_000);
+        expect(calculateTaskPoints(challenge, startTime)).toBe(10);
+    });
+
+    it('challenge definitions still ship the fields scoring depends on', () => {
+        for (const challenge of challenges) {
+            expect(typeof challenge.timeLimit).toBe('number');
+            expect(Array.isArray(challenge.tasks)).toBe(true);
+            expect(challenge.tasks.length).toBeGreaterThan(0);
+        }
+    });
+});


### PR DESCRIPTION
## What does this PR do?

Closes the last two 🔴 bugs from the Phase-0 technical-debt register. Stacked on the stale-state PR.

## Root cause
- **Problem:** (TD-3) completing a level and closing the tab within 30s lost the win — the on-completion save never ran. (TD-6) challenges.js carried dead `endChallenge`/`checkChallengeTask` exports with a divergent scoring formula (100+bonus) players never experienced.
- **Root cause:** the save hook wrapped `window.checkWinCondition`, but the function was never assigned to `window` — dead code; scoring had been reimplemented inline, leaving the dead divergent copy as a trap.
- **Solution:** the save now lives inside `checkWinCondition`'s win path; dead wrapper removed. Dead scoring exports deleted; the live formula (10 + 1pt/10s remaining) exists only in `challenges.js#calculateTaskPoints`, consumed by event-handlers; dead imports cleaned from 3 modules.
- **Why this happened:** an untested integration hook (nothing verified the wrapper ever ran) and copy-instead-of-move refactoring.
- **How we prevent this forever:** regression test proves the save lands with interval timers never firing; `calculateTaskPoints` unit-tested; dead exports deleted rather than kept 'just in case'.

## How was it verified?
unit+regression 19/19 · golden 35/35 · contract 0/0 · lint 0 errors · in-browser: winning level 1 writes the save within a second; challenge task scores 23 (10+bonus) and advances.

**After this stack merges, every 🔴 bug found in the original architecture review (TD-1..TD-4b, TD-6) is fixed and regression-tested.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)