### PR TITLE
chore: hygiene — zero console noise, zero lint warnings, CI-enforced (TD-11) + practice-mode fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: se
 
 ## [Unreleased]
 
+### Fixed (hygiene PR — TD-11 + practice mode)
+- **Cheat Mode practice buttons work again.** The content extraction turned `vimLessons` into a `Map`, but the lookup kept using bracket access — property access on a Map reads nothing, so every Practice button silently did nothing. Fixed with `Map.get` via a named `getPracticeLesson()`; regression-tested end-to-end (every catalog entry must resolve, and starting practice must load the lesson buffer).
+- **Zero console noise in production** (TD-11): ~110 debug `console.log`s deleted (several dumped full buffer state per keystroke); meaningful warnings/errors now flow through the structured logger (`js/logger.js`) with categories (`lesson`, `progress`, `storage`, `ui`) and debug filtering via `localStorage.vimMasterDebug`.
+- **Lint is clean and stays clean:** 195 warnings burned down to **0**; ~170 unused imports/variables removed; `no-console`, `no-unused-vars`, `no-empty`, and `no-debugger` are now ESLint **errors** (with `js/logger.js`, `scripts/`, and `tests/` exempted from `no-console`), enforced by CI on every PR.
+
 ### Fixed (PR26 — completion auto-save & challenge scoring)
 - **Progress is saved the moment a level is won** (TD-3). The intended on-completion save was a dead `window.checkWinCondition` wrapper that never ran; wins relied on the 30-second interval save and could be lost by closing the tab. The save now lives inside the win path itself. Regression-tested.
 - **Challenge task scoring has a single source of truth** (TD-6): dead `endChallenge`/`checkChallengeTask` exports (carrying a divergent 100-points formula players never experienced) are deleted; the live formula (10 + 1 point per 10s remaining) lives only in `challenges.js#calculateTaskPoints`, unit-tested, with dead imports cleaned from three modules.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -9,7 +9,7 @@
 | **Current version** | v3.0.0 — Community Alpha (see [CHANGELOG.md](CHANGELOG.md)) |
 | **Current phase** | ✅ Phase 0 (bugs) · ✅ tooling/tests (unit + contract + golden + regression) · ✅ **content extraction** (35 JSON lessons in `/content/lessons`) → ▶️ Community Alpha hardening ([ROADMAP.md](ROADMAP.md)) |
 | **Current sprint** | PR24: every lesson provably solvable — `solution` in all 35 lessons, Golden Suite auto-verifies each (35/35), L007 promoted to ERROR |
-| **Current focus** | **All 🔴 Phase-0 bugs closed** (TD-1..TD-4b, TD-6 — each regression-tested). Next: lint-warning burn-down (~186), debug-log strip (TD-11), Community Alpha release checklist |
+| **Current focus** | **Codebase hygiene complete**: 0 lint errors/warnings with strict rules in CI, 0 console noise, practice-mode regression fixed. Next: **Community Alpha release checklist** (QUALITY.md) |
 | **Next milestone** | Community Alpha announcement once the release checklist in QUALITY.md is green |
 | **Release target** | v1.0 after the pure-core engine rewrite + platform pages — no date commitment; quality gates over deadlines |
 
@@ -23,7 +23,8 @@
 | TD-4 | ~~Stale cursor clamp (`0` failed past EOL after `j`)~~ ✅ fixed — PR25, regression-tested | ✅ |
 | TD-4b | ~~Counted edits stale/broken (`2x`→1 char; `2dd`/`2dw` never worked)~~ ✅ fixed — PR25, regression-tested | ✅ |
 | TD-6 | ~~Duplicate, divergent challenge scoring~~ ✅ fixed — PR26, single source + unit tests | ✅ |
-| TD-11 | Debug `console.log`s ship to production | 🟡 |
+| TD-11 | ~~Debug `console.log`s ship to production~~ ✅ fixed — hygiene PR: structured logger + `no-console` as CI error | ✅ |
+| — | ~~Cheat Mode practice buttons dead (Map bracket-access lookup)~~ ✅ fixed — hygiene PR, regression-tested | ✅ |
 
 Full register with file/line references: [docs/TechnicalDebt.md](docs/TechnicalDebt.md).
 

--- a/content/index.json
+++ b/content/index.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "contentVersion": 1,
-  "generatedAt": "2026-07-10T09:16:17.358Z",
+  "generatedAt": "2026-07-10T15:15:33.972Z",
   "generator": "scripts/build-content.js",
   "regularLessons": [
     "lesson-how-to-exit-ex-commands",

--- a/docs/TechnicalDebt.md
+++ b/docs/TechnicalDebt.md
@@ -54,7 +54,7 @@ There is no way to programmatically verify anything. Every other fix lands blind
 
 ## 🟡 Maintainability
 
-### TD-11 Shipped debug logging
+### TD-11 Shipped debug logging — ✅ FIXED (hygiene PR: ~110 console.logs deleted, warnings/errors routed through js/logger.js with categories, `no-console`/`no-unused-vars`/`no-empty`/`no-debugger` enforced as ESLint **errors** in CI)
 ~150 `console.log('🔍 DEBUG…')` calls across `event-handlers.js`, `challenges.js`, `progress-system.js`, `ui-components.js`, `cheat-mode.js`, `main.js` — several dump full buffer content **on every keystroke** (`updateUI`). Remove entirely; if diagnostics are wanted, gate behind a `DEBUG` flag.
 
 ### TD-12 Duplicated utility logic

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,10 +13,30 @@ export default [
             }
         },
         rules: {
-            // Keep rules very minimal for now to ease adoption
-            "no-unused-vars": "warn",
+            // Hygiene gate (TD-11): violations are errors so they cannot
+            // creep back in. CI runs eslint on every PR.
+            "no-unused-vars": "error",
             "no-undef": "error",
-            "no-empty": "warn"
+            "no-empty": ["error", { "allowEmptyCatch": false }],
+            "no-debugger": "error",
+            // App code logs through js/logger.js (structured categories,
+            // debug filtering via localStorage.vimMasterDebug) — never
+            // through console directly.
+            "no-console": "error"
+        }
+    },
+    {
+        // The logger's ConsoleAdapter is the one legitimate console user
+        files: ["js/logger.js"],
+        rules: {
+            "no-console": "off"
+        }
+    },
+    {
+        // CLI tooling and test runners print to the terminal by design
+        files: ["scripts/**", "tests/**"],
+        rules: {
+            "no-console": "off"
         }
     }
 ];

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -48,9 +48,6 @@ export const challenges = [
                 instruction: "Delete the word 'remove' from the first line using dw",
                 validation: (gameState) => {
                     const content = gameState.getContent();
-                    console.log('🔍 DEBUG: Challenge validation - content[0]:', content[0]);
-                    console.log('🔍 DEBUG: Challenge validation - expected: "delete this line"');
-                    console.log('🔍 DEBUG: Challenge validation - includes "remove":', content[0].includes("remove"));
                     return content[0] === "delete this line" && !content[0].includes("remove");
                 },
                 hint: "Position cursor on 'r' of 'remove', then use dw"
@@ -118,10 +115,8 @@ export const challenges = [
 
 // Challenge Management Functions
 export const startChallenge = (gameState, challengeIndex = null) => {
-    console.log('🔍 startChallenge called with gameState:', gameState);
     
     if (gameState.currentChallenge) {
-        console.log('🔍 Challenge already exists, returning');
         return;
     }
     
@@ -130,8 +125,6 @@ export const startChallenge = (gameState, challengeIndex = null) => {
         challengeIndex = Math.floor(Math.random() * challenges.length);
     }
     
-    console.log('🔍 Selected challenge index:', challengeIndex);
-    console.log('🔍 Available challenges:', challenges);
     
     gameState.currentChallenge = challenges[challengeIndex];
     gameState.currentTaskIndex = 0;
@@ -139,47 +132,28 @@ export const startChallenge = (gameState, challengeIndex = null) => {
     gameState.challengeProgressValue = 0;
     gameState.challengeStartTime = Date.now();
     
-    console.log('🔍 Challenge selected:', gameState.currentChallenge);
-    console.log('🔍 Challenge initial content:', gameState.currentChallenge.initialContent);
     
     // Load challenge content and update global state
     gameState.content = [...gameState.currentChallenge.initialContent];
     gameState.cursor = { row: 0, col: 0 };
     gameState.mode = 'NORMAL';
     
-    console.log('🔍 Local gameState updated:');
-    console.log('🔍 - content:', gameState.content);
-    console.log('🔍 - cursor:', gameState.cursor);
-    console.log('🔍 - mode:', gameState.mode);
     
     // Update global state using setter functions
-    console.log('🔍 Updating global state...');
     if (gameState.setContent) {
-        console.log('🔍 Calling setContent with:', [...gameState.currentChallenge.initialContent]);
         gameState.setContent([...gameState.currentChallenge.initialContent]);
-    } else {
-        console.log('🔍 setContent function not found!');
     }
     
     if (gameState.setCursor) {
-        console.log('🔍 Calling setCursor with:', { row: 0, col: 0 });
         gameState.setCursor({ row: 0, col: 0 });
-    } else {
-        console.log('🔍 setCursor function not found!');
     }
     
     if (gameState.setMode) {
-        console.log('🔍 Calling setMode with: NORMAL');
         gameState.setMode('NORMAL');
-    } else {
-        console.log('🔍 setMode function not found!');
     }
     
     if (gameState.setCurrentChallenge) {
-        console.log('🔍 Calling setCurrentChallenge with:', challenges[challengeIndex]);
         gameState.setCurrentChallenge(challenges[challengeIndex]);
-    } else {
-        console.log('🔍 setCurrentChallenge function not found!');
     }
     
     if (gameState.setCurrentTaskIndex) gameState.setCurrentTaskIndex(0);
@@ -187,7 +161,6 @@ export const startChallenge = (gameState, challengeIndex = null) => {
     if (gameState.setChallengeProgressValue) gameState.setChallengeProgressValue(0);
     if (gameState.setChallengeStartTime) gameState.setChallengeStartTime(Date.now());
     
-    console.log('🔍 startChallenge returning:', gameState.currentChallenge);
     return gameState.currentChallenge;
 };
 

--- a/js/cheat-mode.js
+++ b/js/cheat-mode.js
@@ -1,13 +1,15 @@
 // VIM Master Game - Cheat Mode & Real VIM Lessons
 
-import { 
-    getPracticedCommands, getCurrentLevel, getContent, setContent, getCursor, setCursor, getMode, setMode,
-    getCommandHistory, setCommandHistory, getCommandLog, setCommandLog, addPracticedCommand
+import {
+    getPracticedCommands, getContent, setContent, getCursor,
+    setCursor, getMode, setMode, getCommandHistory,
+    setCommandHistory, getCommandLog, setCommandLog, addPracticedCommand
 } from './game-state.js';
 import { loadPracticeLessons } from './content-loader.js';
 
 import { initializeLessonState } from './levels.js';
 import { updateUI } from './event-handlers.js';
+import { logger, CATEGORIES } from './logger.js';
 
 // Command catalog with real VIM lessons
 const commandCatalog = [
@@ -60,7 +62,6 @@ practiceLessons.forEach(lesson => {
 
 // Practice mode state
 let practiceMode = false;
-let currentPractice = null; // catalog item selected
 let originalGameState = null;
 let currentLessonSpec = null; // resolved lesson data
 
@@ -136,22 +137,27 @@ export function closeCheat(cheatOverlay, cheatPanel, editorInput) {
     if (editorInput) editorInput.focus();
 }
 
+// Resolve a catalog entry to its practice lesson. `vimLessons` is a Map —
+// bracket access on a Map reads properties, not entries, which silently
+// broke every Practice button (see practice-mode-lookup regression test).
+export function getPracticeLesson(catalogId) {
+    return vimLessons.get(catalogId) || null;
+}
+
 // Practice Mode Functions - Now creates real VIM lessons
-function startCheatPractice(item) {
+export function startCheatPractice(item) {
     if (practiceMode) {
-        console.log('Already in practice mode');
         return;
     }
-    
-    const lesson = vimLessons[item.id];
+
+    const lesson = getPracticeLesson(item.id);
     if (!lesson) {
-        console.log('No lesson found for:', item.id);
+        logger.warn(CATEGORIES.LESSON, `No practice lesson found for cheat-sheet entry '${item.id}'`, { catalogId: item.id });
         return;
     }
     
     // Enter practice mode
     practiceMode = true;
-    currentPractice = item;
     
     // Save current game state
     originalGameState = {
@@ -166,8 +172,7 @@ function startCheatPractice(item) {
     // (docs/architecture/level-lifecycle.md — same path as real levels)
     if (!initializeLessonState(lesson)) {
         practiceMode = false;
-        currentPractice = null;
-        originalGameState = null;
+            originalGameState = null;
         return;
     }
 
@@ -175,16 +180,13 @@ function startCheatPractice(item) {
     currentLessonSpec = lesson;
     
     // Update the UI to show the lesson
-    console.log('🔍 DEBUG: About to call updateUI(), current content:', getContent());
     updateUI();
-    console.log('🔍 DEBUG: After updateUI(), current content:', getContent());
     
     // IMPORTANT: Update the instructions to show the lesson instructions instead of level instructions
     import('./ui-components.js').then(({ updateInstructions }) => {
-        console.log('🔍 DEBUG: Calling updateInstructions() for lesson:', lesson.name);
         updateInstructions();
     }).catch(error => {
-        console.error('🔍 ERROR: Failed to update instructions:', error);
+        logger.error(CATEGORIES.UI, 'Failed to update instructions', { error: error.message });
     });
     
     // Auto-close cheat panel for better UX
@@ -210,9 +212,7 @@ function startCheatPractice(item) {
     // We intentionally avoid auto-focus and custom key handlers here.
      
      // Show lesson interface AFTER focusing the editor
-     console.log('🔍 DEBUG: About to show lesson interface, current activeElement:', document.activeElement);
      showLessonInterface(item, lesson);
-     console.log('🔍 DEBUG: After showing lesson interface, current activeElement:', document.activeElement);
      
      // Mark as practiced
      addPracticedCommand(item.id);
@@ -223,7 +223,6 @@ function startCheatPractice(item) {
         if (editorInput) editorInput.focus();
     }, 100);
     
-    console.log(`Started VIM lesson for: ${item.key}`);
 }
 
 function showLessonInterface(item, lesson) {
@@ -275,8 +274,6 @@ export function checkPracticeCompletion() {
     const lesson = currentLessonSpec;
     const currentCursor = getCursor();
     const currentContent = getContent();
-    // Debug: minimal insight while testing
-    // console.log('Practice check:', lesson.name, 'cursor', currentCursor);
     
     if (lesson.target && isTargetReached(currentCursor, lesson.target)) {
         showLessonCompletion(lesson, 'Target reached!');
@@ -360,7 +357,6 @@ function showLessonCompletion(lesson, message) {
         exitPracticeMode();
     });
     
-    console.log('🎉 Completion overlay created and displayed!');
 }
 
 function closeLesson() {
@@ -376,19 +372,12 @@ function closeLesson() {
     // practiceMode = false;  ← REMOVED
     // currentPractice = null; ← REMOVED
     
-    console.log('Lesson overlay closed - continue practicing in main editor');
-    console.log('Practice mode remains active - completion monitor continues running');
 }
 
 // Function to exit practice mode and restore game state
 export function exitPracticeMode() {
     if (!practiceMode) return;
     
-         // Clean up event handlers
-     const editorContainer = document.getElementById('editor-container');
-     if (editorContainer) {
-         console.log('Cleaned up cheat mode event handlers');
-     }
     
     // Restore original game state
     if (originalGameState) {
@@ -418,13 +407,11 @@ export function exitPracticeMode() {
     
     // Reset practice mode
     practiceMode = false;
-    currentPractice = null;
     originalGameState = null;
     
     // Update UI
     updateUI();
     
-    console.log('Exited practice mode and restored game state');
 }
 
 // Export command catalog for other modules

--- a/js/event-handlers.js
+++ b/js/event-handlers.js
@@ -1,36 +1,33 @@
 // VIM Master Game - Event Handlers
 
-import { 
-    getContent, getCursor, getMode, getCurrentLevel, getCommandHistory, getCommandLog,
-    getYankedLine, getReplacePending, getCountBuffer, getUndoStack, getRedoStack,
-    getLevel12Undo, getLevel12RedoAfterUndo, getLastExCommand, getSearchMode,
-    getSearchQuery, getLastSearchQuery, getLastSearchDirection, getSearchMatches,
-    getCurrentMatchIndex, getUsedSearchInLevel, getNavCountSinceSearch, getBadges,
-    getPracticedCommands, getChallengeMode, getCurrentChallenge, getChallengeTimerInterval,
-    getChallengeStartTime, getChallengeScoreValue, getChallengeProgressValue, getCurrentTaskIndex,
-    cloneState, pushUndo, escapeHtml, isEscapeKey, resetGameState, resetChallengeState, resetLevelState,
-    setChallengeMode, setCurrentLevel, setContent, setCursor, setMode, setCommandHistory,
-    setCommandLog, setYankedLine, setReplacePending, setCountBuffer, setSearchMode,
-    setSearchQuery, setLastSearchQuery, setLastSearchDirection, setSearchMatches,
-    setCurrentMatchIndex, setUsedSearchInLevel, setNavCountSinceSearch, setLevel12Undo,
-    setLevel12RedoAfterUndo, setLastExCommand, setCurrentChallenge, setCurrentTaskIndex,
-    setChallengeScoreValue, setChallengeProgressValue, setChallengeStartTime,
-    setChallengeTimerInterval, addBadge, getXp, getCombo, setXp, setCombo
+import {
+    getContent, getCursor, getMode, getCurrentLevel,
+    getCommandHistory, getCommandLog, getYankedLine, getReplacePending,
+    getCountBuffer, getUndoStack, getRedoStack, getLevel12Undo,
+    getLevel12RedoAfterUndo, getLastExCommand, getSearchMode, getSearchQuery,
+    getLastSearchQuery, getLastSearchDirection, getSearchMatches, getCurrentMatchIndex,
+    getUsedSearchInLevel, getNavCountSinceSearch, getBadges, getPracticedCommands,
+    getChallengeMode, getCurrentChallenge, getChallengeTimerInterval, getChallengeStartTime,
+    getChallengeScoreValue, getChallengeProgressValue, getCurrentTaskIndex, resetChallengeState,
+    resetLevelState, setChallengeMode, setCurrentLevel, setContent,
+    setCursor, setMode, setLastExCommand, setCurrentChallenge,
+    setCurrentTaskIndex, setChallengeScoreValue, setChallengeProgressValue, setChallengeStartTime,
+    setChallengeTimerInterval, addBadge, getXp, getCombo,
+    setXp, setCombo
 } from './game-state.js';
 
-import { levels, loadLevel, getCurrentLevelFromGameState, getLevelCount, isLastLevel } from './levels.js';
-import { isInPracticeMode, getCurrentLessonSpec } from './cheat-mode.js';
-import { challenges, startChallenge, getChallengeTimeRemaining, calculateTaskPoints } from './challenges.js';
-import { handleNormalMode, handleInsertMode, handleSearchMode } from './vim-commands.js';
-import { 
-    renderEditor, updateStatusBar, updateInstructions, updateLevelIndicator, 
-    updateCommandLog, createLevelButtons, renderBadges, showModal, hideModal,
-    showCelebration, hideCelebration, flashLevelComplete, updateChallengeUI,
-    showChallengeContainer, hideChallengeContainer, showBadgeToast, flashError, updateStatsBar
+import { levels, loadLevel } from './levels.js';
+import { isInPracticeMode } from './cheat-mode.js';
+import { startChallenge, getChallengeTimeRemaining, calculateTaskPoints } from './challenges.js';
+import {
+    renderEditor, updateStatusBar, updateInstructions, updateLevelIndicator,
+    updateCommandLog, createLevelButtons, renderBadges, showModal,
+    showCelebration, flashLevelComplete, updateChallengeUI, showChallengeContainer,
+    hideChallengeContainer, showBadgeToast, flashError, updateStatsBar
 } from './ui-components.js';
-import { openCheat, closeCheat, renderCheatList } from './cheat-mode.js';
 import { autoSaveProgress } from './progress-system.js';
 import { evaluateWinCondition } from './win-evaluator.js';
+import { logger, CATEGORIES } from './logger.js';
 
 // Game Logic Functions
 export function checkWinCondition() {
@@ -39,8 +36,6 @@ export function checkWinCondition() {
         const challenge = getCurrentChallenge();
         const currentTask = challenge.tasks[getCurrentTaskIndex()];
         
-        console.log('🔍 Checking challenge task:', currentTask.instruction);
-        console.log('🔍 Current task index:', getCurrentTaskIndex());
         
         if (currentTask.validation) {
             // Create a gameState object for validation
@@ -50,28 +45,21 @@ export function checkWinCondition() {
                 getYankedLine: getYankedLine
             };
             
-            console.log('🔍 DEBUG: Running challenge validation for task:', currentTask.instruction);
-            console.log('🔍 DEBUG: Current content:', getContent());
-            console.log('🔍 DEBUG: Current cursor:', getCursor());
             
             const validationResult = currentTask.validation(gameState);
-            console.log('🔍 DEBUG: Validation result:', validationResult);
             
             if (validationResult) {
-                console.log('🔍 Challenge task completed!');
                 
                  // Award points via the single scoring source of truth (TD-6)
                  const taskPoints = calculateTaskPoints(challenge, getChallengeStartTime());
                  setChallengeScoreValue(getChallengeScoreValue() + taskPoints);
                  
-                 console.log('🔍 Task completed! Points awarded:', taskPoints, 'Total score:', getChallengeScoreValue());
                  
                  // Auto-save progress to persist challenge points
                  try {
                      autoSaveProgress();
-                     console.log('🔍 Progress auto-saved with challenge points');
                  } catch (error) {
-                     console.warn('Failed to auto-save progress:', error);
+                     logger.warn(CATEGORIES.PROGRESS, 'Failed to auto-save progress', { error: error.message });
                  }
                 
                 // Move to next task or complete challenge
@@ -98,7 +86,6 @@ export function checkWinCondition() {
                      return; // Don't show win condition yet
                  } else {
                      // Challenge completed!
-                     console.log('🔍 Challenge completed!');
                      hideChallengeContainer();
                      
                      // Disable challenge mode to stop timer
@@ -108,16 +95,11 @@ export function checkWinCondition() {
                      // Auto-save final challenge points
                      try {
                          autoSaveProgress();
-                         console.log('🔍 Final challenge points saved to progress');
                      } catch (error) {
-                         console.warn('Failed to save final challenge points:', error);
+                         logger.warn(CATEGORIES.PROGRESS, 'Failed to save final challenge points', { error: error.message });
                      }
                      
                      // Debug modal elements
-                     console.log('🔍 Modal elements check:');
-                     console.log('🔍 - modal:', document.getElementById('modal'));
-                     console.log('🔍 - modalTitle:', document.getElementById('modal-title'));
-                     console.log('🔍 - modalMessage:', document.getElementById('modal-message'));
                      
                      // Show completion modal with option to play again
                      showModal('🎉 Challenge Complete!', 
@@ -130,14 +112,6 @@ export function checkWinCondition() {
                          </button>`
                      );
                      
-                     console.log('🔍 showModal called, checking if modal is visible...');
-                     setTimeout(() => {
-                         const modal = document.getElementById('modal');
-                         if (modal) {
-                             console.log('🔍 Modal classes:', modal.className);
-                             console.log('🔍 Modal style:', modal.style.cssText);
-                         }
-                     }, 100);
                      
                      return;
                  }
@@ -186,7 +160,7 @@ export function checkWinCondition() {
                     window.updateProgressSummary();
                 }
             } catch (error) {
-                console.warn('Failed to auto-save progress on level completion:', error);
+                logger.warn(CATEGORIES.PROGRESS, 'Failed to auto-save progress on level completion', { error: error.message });
             }
 
             // Check if this is the final level
@@ -251,7 +225,7 @@ export function maybeAwardBadges() {
                  if (typeof window.updateProgressSummary === 'function') {
                      window.updateProgressSummary();
                  }
-             } catch (error) {
+             } catch {
                  // Progress system not available, continue without auto-save
              }
          }, 1000);
@@ -283,14 +257,10 @@ export function resetLevel() {
 
 // Challenge Functions
 export function toggleChallengeMode() {
-    console.log('🔍 toggleChallengeMode called');
-    console.log('🔍 Current challenge mode:', getChallengeMode());
     
     setChallengeMode(!getChallengeMode());
-    console.log('🔍 New challenge mode:', getChallengeMode());
     
     if (getChallengeMode()) {
-        console.log('🔍 Starting challenge mode...');
         showChallengeContainer();
         
         const gameStateObj = {
@@ -316,17 +286,11 @@ export function toggleChallengeMode() {
             getContent, getCursor, getYankedLine
         };
         
-        console.log('🔍 Game state object created:', gameStateObj);
-        console.log('🔍 Current content before challenge:', getContent());
         
         const challenge = startChallenge(gameStateObj);
-        console.log('🔍 Challenge returned:', challenge);
         
         // Update the challenge UI with the challenge data
         if (challenge) {
-            console.log('🔍 Challenge name:', challenge.name);
-            console.log('🔍 Challenge content:', challenge.initialContent);
-            console.log('🔍 Current content after challenge:', getContent());
             
             updateChallengeUI(challenge, 0, 0, challenge.timeLimit);
             
@@ -335,7 +299,6 @@ export function toggleChallengeMode() {
                  // Check if challenge is still active
                  if (!getChallengeMode() || !getCurrentChallenge()) {
                      clearInterval(timerInterval);
-                     console.log('🔍 Timer stopped - challenge mode disabled or no current challenge');
                      return;
                  }
                  
@@ -344,12 +307,10 @@ export function toggleChallengeMode() {
                      challengeStartTime: getChallengeStartTime()
                  });
                  
-                 console.log('🔍 Timer tick - time remaining:', timeRemaining, 'seconds');
                  
                  if (timeRemaining <= 0) {
                      // Time's up - end the challenge
                      clearInterval(timerInterval);
-                     console.log('🔍 Time up! Ending challenge...');
                      
                      // Only show timeout modal if challenge hasn't been completed
                      if (getChallengeMode()) {
@@ -374,21 +335,17 @@ export function toggleChallengeMode() {
             setChallengeTimerInterval(timerInterval);
         }
         
-        console.log('🔍 About to call updateUI()');
         // Update the main UI to show challenge content
         updateUI();
-        console.log('🔍 updateUI() called, current content:', getContent());
         
         // Ensure editor gets focus for immediate input
         setTimeout(() => {
             const editorInput = document.getElementById('vim-editor-input');
             if (editorInput) {
                 editorInput.focus();
-                console.log('🔍 Editor focused for challenge mode');
             }
         }, 100);
     } else {
-        console.log('🔍 Exiting challenge mode...');
         hideChallengeContainer();
         // Return to current level
         loadLevel(getCurrentLevel());
@@ -401,15 +358,10 @@ let _isUpdatingUI = false; // Guard against infinite loops
 
 export function updateUI() {
     if (_isUpdatingUI) {
-        console.log('🔍 updateUI already running, skipping');
         return;
     }
     
     _isUpdatingUI = true;
-    console.log('🔍 updateUI called');
-    console.log('🔍 Current content in updateUI:', getContent());
-    console.log('🔍 Current cursor in updateUI:', getCursor());
-    console.log('🔍 Current mode in updateUI:', getMode());
     
     try {
         renderEditor(getContent(), getCursor(), getMode());
@@ -420,20 +372,15 @@ export function updateUI() {
         
         // Fix stuck challenge mode state - if we're not in practice mode and no current challenge, reset challenge mode
         if (getChallengeMode() && !isInPracticeMode() && !getCurrentChallenge()) {
-            console.log('🔍 DEBUG: Fixing stuck challenge mode state');
             setChallengeMode(false);
             setCurrentChallenge(null);
         }
         
         // Hide level indicator and buttons in challenge mode or practice mode
-        console.log('🔍 DEBUG: getChallengeMode():', getChallengeMode());
-        console.log('🔍 DEBUG: isInPracticeMode():', isInPracticeMode());
         if (getChallengeMode() || isInPracticeMode()) {
-            console.log('🔍 DEBUG: Hiding level indicator - in challenge or practice mode');
             updateLevelIndicator(-1, 0); // Hide level indicator
             // Don't create level buttons in challenge mode or practice mode
         } else {
-            console.log('🔍 DEBUG: Showing level indicator - current level:', getCurrentLevel(), 'total levels:', levels.length);
             updateLevelIndicator(getCurrentLevel(), levels.length);
             createLevelButtons(levels, getCurrentLevel());
         }
@@ -446,7 +393,6 @@ export function updateUI() {
             updateStatsBar(module.getCombo(), module.getXp());
         });
         
-        console.log('🔍 updateUI completed');
     } finally {
         _isUpdatingUI = false;
     }

--- a/js/generated-content.js
+++ b/js/generated-content.js
@@ -9,7 +9,7 @@ export const generatedContent = {
   "index": {
     "version": 1,
     "contentVersion": 1,
-    "generatedAt": "2026-07-10T09:16:17.358Z",
+    "generatedAt": "2026-07-10T15:15:33.972Z",
     "generator": "scripts/build-content.js",
     "regularLessons": [
       "lesson-how-to-exit-ex-commands",

--- a/js/levels.js
+++ b/js/levels.js
@@ -1,23 +1,14 @@
 // VIM Master Game - Level Definitions and Management
 
 // Import global state variables for backward compatibility
-import { 
-    getContent, getCursor, getMode, getCurrentLevel, getCommandHistory, getCommandLog,
-    getYankedLine, getReplacePending, getCountBuffer, getUndoStack, getRedoStack,
-    getLevel12Undo, getLevel12RedoAfterUndo, getLastExCommand, getSearchMode,
-    getSearchQuery, getLastSearchQuery, getLastSearchDirection, getSearchMatches,
-    getCurrentMatchIndex, getUsedSearchInLevel, getNavCountSinceSearch, getBadges,
-    getPracticedCommands, getChallengeMode, getCurrentChallenge, getChallengeTimerInterval,
-    getChallengeStartTime, getChallengeScoreValue, getChallengeProgressValue, getCurrentTaskIndex,
-    resetLevelState, resetChallengeState, setContent, setCursor, setMode, setCurrentLevel,
-    setCommandHistory, setCommandLog, setYankedLine, setReplacePending, setCountBuffer,
-    setSearchMode, setSearchQuery, setLastSearchQuery, setLastSearchDirection, setSearchMatches,
-    setCurrentMatchIndex, setUsedSearchInLevel, setNavCountSinceSearch, setLevel12Undo,
-    setLevel12RedoAfterUndo, setLastExCommand
+import {
+    resetLevelState, setContent, setCursor, setMode,
+    setCurrentLevel, setCommandHistory
 } from './game-state.js';
 
 // Level Definitions
 import { loadRegularLessons } from './content-loader.js';
+import { logger, CATEGORIES } from './logger.js';
 export const levels = loadRegularLessons();
 
 // Lesson Initialization Pipeline
@@ -45,7 +36,7 @@ const PASSIVE_LESSON_PROPS = ['id', 'version', 'metadata', 'focusCommand', 'solu
 export const initializeLessonState = (lesson) => {
     // --- lesson validates -------------------------------------------------
     if (!lesson || !Array.isArray(lesson.initialContent) || lesson.initialContent.length === 0) {
-        console.warn(`VIMMaster: lesson "${lesson?.name ?? '?'}" has no valid initialContent buffer — not loaded`);
+        logger.warn(CATEGORIES.LESSON, `Lesson "${lesson?.name ?? '?'}" has no valid initialContent buffer — not loaded`, { lessonId: lesson?.id });
         return false;
     }
 
@@ -64,7 +55,7 @@ export const initializeLessonState = (lesson) => {
     const objectives = WIN_CONDITION_PROPS.filter((prop) => prop in lesson);
     objectives.forEach(read);
     if (objectives.length !== 1) {
-        console.warn(`VIMMaster: lesson "${lesson.name}" must define exactly one win condition, found ${objectives.length}${objectives.length ? `: ${objectives.join(', ')}` : ''}`);
+        logger.warn(CATEGORIES.LESSON, `Lesson "${lesson.name}" must define exactly one win condition, found ${objectives.length}`, { lessonId: lesson.id, objectives });
     }
 
     // --- state initializes ------------------------------------------------
@@ -103,7 +94,7 @@ export const initializeLessonState = (lesson) => {
     const row = Math.min(Math.max(requestedRow, 0), buffer.length - 1);
     const col = Math.min(Math.max(requestedCol, 0), Math.max(0, buffer[row].length - 1));
     if (row !== requestedRow || col !== requestedCol) {
-        console.warn(`VIMMaster: lesson "${lesson.name}" start cursor {${requestedRow},${requestedCol}} is outside the buffer — clamped to {${row},${col}}`);
+        logger.warn(CATEGORIES.LESSON, `Lesson "${lesson.name}" start cursor {${requestedRow},${requestedCol}} is outside the buffer — clamped to {${row},${col}}`, { lessonId: lesson.id });
     }
 
     setCursor({ row, col });
@@ -113,7 +104,7 @@ export const initializeLessonState = (lesson) => {
     // --- consumption check --------------------------------------------------
     const unconsumed = Object.keys(lesson).filter((key) => !consumed.has(key));
     if (unconsumed.length > 0) {
-        console.warn(`VIMMaster: lesson "${lesson.name}" has properties that were never consumed during initialization: ${unconsumed.join(', ')} — see docs/architecture/level-lifecycle.md`);
+        logger.warn(CATEGORIES.LESSON, `Lesson "${lesson.name}" has properties that were never consumed during initialization: ${unconsumed.join(', ')} — see docs/architecture/level-lifecycle.md`, { lessonId: lesson.id, unconsumed });
     }
 
     // buffer rendered / game starts: the caller triggers updateUI()

--- a/js/logger.js
+++ b/js/logger.js
@@ -96,7 +96,7 @@ class Logger {
             } else if (['localhost', '127.0.0.1'].includes(window.location.hostname)) {
                 isDev = true;
             }
-        } catch (e) {
+        } catch {
             // In case we're in an environment without window/localStorage
         }
         
@@ -121,7 +121,7 @@ class Logger {
                 // If development mode is on but no specific filter is set, show all logs.
                 this.config.debugAll = true;
             }
-        } catch (e) {
+        } catch {
             this.config.debugAll = true;
         }
     }

--- a/js/main.js
+++ b/js/main.js
@@ -1,41 +1,28 @@
 // VIM Master Game - Main Entry Point
 
-import { 
-    getContent, getCursor, getMode, getCurrentLevel, getCommandHistory, getCommandLog, 
-    getYankedLine, getReplacePending, getCountBuffer, getUndoStack, getRedoStack,
-    getLevel12Undo, getLevel12RedoAfterUndo, getLastExCommand, getSearchMode,
-    getSearchQuery, getLastSearchQuery, getLastSearchDirection, getSearchMatches,
-    getCurrentMatchIndex, getUsedSearchInLevel, getNavCountSinceSearch, getBadges,
-    getPracticedCommands, getChallengeMode, getCurrentChallenge, getChallengeTimerInterval,
-    getChallengeStartTime, getChallengeScoreValue, getChallengeProgressValue, getCurrentTaskIndex,
-    cloneState, pushUndo, escapeHtml, isEscapeKey, resetGameState, resetChallengeState, resetLevelState,
-    setCurrentLevel, setContent, setCursor, setMode, setCommandHistory, setCommandLog,
-    setYankedLine, setReplacePending, setCountBuffer, setSearchMode, setSearchQuery,
-    setLastSearchQuery, setLastSearchDirection, setSearchMatches, setCurrentMatchIndex,
-    setUsedSearchInLevel, setNavCountSinceSearch, setLevel12Undo, setLevel12RedoAfterUndo,
-    setLastExCommand, setChallengeMode, setCurrentChallenge, setChallengeTimerInterval,
-    setChallengeStartTime, setChallengeScoreValue, setChallengeProgressValue, setCurrentTaskIndex,
+import {
+    getMode, getCurrentLevel, getSearchMode, getBadges,
+    getPracticedCommands, resetGameState, setCurrentLevel, setChallengeMode,
     setBadges, setPracticedCommands
 } from './game-state.js';
 
-import { levels, loadLevel, getLevelCount, isLastLevel } from './levels.js';
-import { challenges, startChallenge } from './challenges.js';
+import { levels, loadLevel } from './levels.js';
 import { handleNormalMode, handleInsertMode, handleSearchMode } from './vim-commands.js';
-import { 
-    initializeDOMReferences, renderEditor, updateStatusBar, updateInstructions, 
-    updateLevelIndicator, updateCommandLog, createLevelButtons, renderBadges, 
-    showModal, hideModal, showCelebration, hideCelebration, flashLevelComplete,
-    updateChallengeUI, showChallengeContainer, hideChallengeContainer, showBadgeToast,
-    initOnboarding
+import {
+    initializeDOMReferences, updateLevelIndicator, createLevelButtons, hideModal,
+    showCelebration, hideCelebration, initOnboarding
 } from './ui-components.js';
-import { openCheat, closeCheat, renderCheatList, isInPracticeMode, checkPracticeCompletion } from './cheat-mode.js';
-import { 
-    checkWinCondition, maybeAwardBadges, nextLevel, previousLevel, resetLevel,
-    toggleChallengeMode, updateUI
+import {
+    openCheat, closeCheat, renderCheatList, isInPracticeMode,
+    checkPracticeCompletion
+} from './cheat-mode.js';
+import {
+    checkWinCondition, nextLevel, resetLevel, toggleChallengeMode,
+    updateUI
 } from './event-handlers.js';
-import { 
-    progressSystem, exportProgress, importProgress, autoLoadProgress, 
-    autoSaveProgress, clearProgress, getProgressSummary 
+import {
+    progressSystem, exportProgress, importProgress, autoLoadProgress,
+    autoSaveProgress, clearProgress
 } from './progress-system.js';
 
 
@@ -85,7 +72,6 @@ function setupEventListeners() {
     const celebrationRestartBtn = document.getElementById('celebration-restart');
     const levelSelectionContainer = document.getElementById('level-selection');
     const challengeToggleBtn = document.getElementById('challenge-toggle');
-    const cheatToggleBtn = document.getElementById('cheat-toggle');
     const cheatOverlay = document.getElementById('cheat-overlay');
     const cheatCloseBtn = document.getElementById('cheat-close');
     const cheatSearch = document.getElementById('cheat-search');
@@ -104,7 +90,6 @@ function setupEventListeners() {
     const importCode = document.getElementById('import-code');
     const copyExportBtn = document.getElementById('copy-export-btn');
     const confirmImportBtn = document.getElementById('confirm-import-btn');
-    const progressMessage = document.getElementById('progress-message');
 
     // Progress Toggle Functionality
     if (progressToggle && progressDetails) {
@@ -141,7 +126,7 @@ function setupEventListeners() {
             try {
                 await navigator.clipboard.writeText(exportCode.value);
                 showProgressMessage('Progress code copied to clipboard!', 'success');
-            } catch (error) {
+            } catch {
                 showProgressMessage('Failed to copy code', 'error');
             }
         });
@@ -222,7 +207,6 @@ function setupEventListeners() {
             // Allow VIM commands in cheat mode even if lesson overlay is visible
             if (isInPracticeMode()) {
                 // We're in cheat mode, allow VIM commands to work regardless of overlays
-                console.log('🔍 DEBUG: Practice mode detected, allowing VIM commands');
             } else {
                 // Check for lesson overlay in non-practice mode
                 const lessonOverlay = document.getElementById('lesson-overlay');
@@ -232,7 +216,6 @@ function setupEventListeners() {
                 }
             }
             
-            console.log('🔍 DEBUG: Main game keyboard handler processing key:', e.key);
             
             // Handle Ctrl+R redo before other commands
             if (getMode() === 'NORMAL' && e.key === 'r' && e.ctrlKey) {
@@ -258,7 +241,7 @@ function setupEventListeners() {
             updateUI();
             if (isInPracticeMode()) {
                 // Event-driven practice completion
-                try { checkPracticeCompletion(); } catch {}
+                try { checkPracticeCompletion(); } catch { /* completion check must never break input */ }
             } else {
                 checkWinCondition();
             }

--- a/js/profile-page.js
+++ b/js/profile-page.js
@@ -1,15 +1,14 @@
 // VIM Master Profile Page - Main JavaScript
 
-import { 
-    getBadges, getPracticedCommands, getCurrentLevel, getChallengeMode,
-    setBadges, setPracticedCommands, setCurrentLevel, setChallengeMode
+import {
+    getBadges, setBadges, setPracticedCommands, setCurrentLevel,
+    setChallengeMode
 } from './game-state.js';
+import { logger, CATEGORIES } from './logger.js';
 
 import { exportProgress } from './progress-system.js';
 
-import { 
-    sharingSystem, generateCard, generateProfileCard, generateAsciiLogo
-} from './sharing-system.js';
+import { sharingSystem, generateProfileCard, generateAsciiLogo } from './sharing-system.js';
 
 // Profile page initialization
 function initializeProfilePage() {
@@ -56,12 +55,9 @@ function loadProgressData() {
                 setChallengeMode(progressData.challengeMode);
             }
             
-            console.log('Progress data loaded:', progressData);
-        } else {
-            console.log('No saved progress found in localStorage');
         }
     } catch (error) {
-        console.error('Failed to load progress data:', error);
+        logger.error(CATEGORIES.PROGRESS, 'Failed to load progress data', { error: error.message });
     }
 }
 
@@ -112,7 +108,7 @@ function generateProfileSection() {
         const profileCard = generateProfileCard();
         container.innerHTML = profileCard;
     } catch (error) {
-        console.error('Failed to generate profile card:', error);
+        logger.error(CATEGORIES.UI, 'Failed to generate profile card', { error: error.message });
         container.innerHTML = `
             <div class="bg-gradient-to-br from-red-900/50 to-red-800/50 rounded-xl p-8 border border-red-600/50 backdrop-blur-sm text-center">
                 <div class="text-6xl mb-4">⚠️</div>
@@ -240,7 +236,7 @@ function generateAchievementSection() {
         });
         
     } catch (error) {
-        console.error('Failed to generate achievement cards:', error);
+        logger.error(CATEGORIES.UI, 'Failed to generate achievement cards', { error: error.message });
         container.innerHTML = `
             <div class="bg-gradient-to-br from-red-900/50 to-red-800/50 rounded-xl p-8 border border-red-600/50 backdrop-blur-sm text-center">
                 <div class="text-6xl mb-4">⚠️</div>
@@ -301,7 +297,7 @@ function setupCopyProgressCode() {
             // Show success message
             showCopySuccessMessage();
         } catch (error) {
-            console.error('Failed to copy progress code:', error);
+            logger.error(CATEGORIES.UI, 'Failed to copy progress code', { error: error.message });
             showCopyErrorMessage();
         }
     };

--- a/js/progress-system.js
+++ b/js/progress-system.js
@@ -1,11 +1,14 @@
 // VIM Master Game - Progress Save/Load System
 
 import {
-    getBadges, getPracticedCommands, getCurrentLevel, getChallengeMode, getChallengeScoreValue, getXp, getCombo,
-    setBadges, setPracticedCommands, setCurrentLevel, setChallengeMode, setChallengeScoreValue, setXp, setCombo
+    getBadges, getPracticedCommands, getCurrentLevel, getChallengeMode,
+    getChallengeScoreValue, getXp, getCombo, setBadges,
+    setPracticedCommands, setCurrentLevel, setChallengeMode, setChallengeScoreValue,
+    setXp, setCombo
 } from './game-state.js';
 
 import { levels } from './levels.js';
+import { logger, CATEGORIES } from './logger.js';
 
 // Progress System Class
 class ProgressSystem {
@@ -42,7 +45,7 @@ class ProgressSystem {
             // Add prefix for easy identification
             return this.exportPrefix + base64String;
         } catch (error) {
-            console.error('Export failed:', error);
+            logger.error(CATEGORIES.PROGRESS, 'Export failed', { error: error.message });
             throw new Error('Failed to export progress data');
         }
     }
@@ -69,7 +72,7 @@ class ProgressSystem {
             let jsonString;
             try {
                 jsonString = atob(code);
-            } catch (error) {
+            } catch {
                 return { success: false, message: 'Invalid import code encoding' };
             }
 
@@ -77,7 +80,7 @@ class ProgressSystem {
             let progressData;
             try {
                 progressData = JSON.parse(jsonString);
-            } catch (error) {
+            } catch {
                 return { success: false, message: 'Invalid import code data' };
             }
 
@@ -99,7 +102,7 @@ class ProgressSystem {
             };
 
         } catch (error) {
-            console.error('Import failed:', error);
+            logger.error(CATEGORIES.PROGRESS, 'Import failed', { error: error.message });
             return { success: false, message: 'Failed to import progress data' };
         }
     }
@@ -117,7 +120,6 @@ class ProgressSystem {
         
         // Handle challenge points - if not present, default to 0
         if (data.challengePoints === undefined) {
-            console.log('🔍 DEBUG: Challenge points not found in progress data, defaulting to 0');
             data.challengePoints = 0;
         }
         
@@ -191,7 +193,7 @@ class ProgressSystem {
                 raw
             }));
         } catch (error) {
-            console.warn('Failed to back up progress data:', error);
+            logger.warn(CATEGORIES.STORAGE, 'Failed to back up progress data', { error: error.message });
         }
     }
 
@@ -200,7 +202,6 @@ class ProgressSystem {
      * @param {Object} data - Validated progress data
      */
     applyProgressData(data) {
-        console.log('🔍 DEBUG: applyProgressData - applying challenge points:', data.challengePoints);
         
         // Apply badges
         setBadges(data.badges);
@@ -222,7 +223,6 @@ class ProgressSystem {
         setXp(data.xp || 0);
         setCombo(data.combo || 0);
         
-        console.log('🔍 DEBUG: applyProgressData - after setting, getChallengeScoreValue():', getChallengeScoreValue());
     }
 
     /**
@@ -233,7 +233,7 @@ class ProgressSystem {
         try {
             localStorage.setItem(this.storageKey, JSON.stringify(data));
         } catch (error) {
-            console.warn('Failed to save progress to localStorage:', error);
+            logger.warn(CATEGORIES.STORAGE, 'Failed to save progress to localStorage', { error: error.message });
         }
     }
 
@@ -248,7 +248,7 @@ class ProgressSystem {
                 return JSON.parse(stored);
             }
         } catch (error) {
-            console.warn('Failed to load progress from localStorage:', error);
+            logger.warn(CATEGORIES.STORAGE, 'Failed to load progress from localStorage', { error: error.message });
         }
         return null;
     }
@@ -267,7 +267,7 @@ class ProgressSystem {
         try {
             raw = localStorage.getItem(this.storageKey);
         } catch (error) {
-            console.warn('Failed to access saved progress:', error);
+            logger.warn(CATEGORIES.STORAGE, 'Failed to access saved progress', { error: error.message });
             return { loaded: false, repaired: false, message: null };
         }
 
@@ -279,7 +279,7 @@ class ProgressSystem {
         try {
             stored = JSON.parse(raw);
         } catch (error) {
-            console.warn('Saved progress is not valid JSON:', error);
+            logger.warn(CATEGORIES.STORAGE, 'Saved progress is not valid JSON', { error: error.message });
         }
 
         if (stored) {
@@ -317,7 +317,6 @@ class ProgressSystem {
     autoSaveProgress() {
         try {
             const challengePoints = getChallengeScoreValue();
-            console.log('🔍 DEBUG: autoSaveProgress - challengePoints:', challengePoints);
             
             const currentProgress = {
                 version: this.version,
@@ -328,10 +327,9 @@ class ProgressSystem {
                 challengeMode: getChallengeMode(),
                 challengePoints: challengePoints || 0
             };
-            console.log('🔍 DEBUG: autoSaveProgress - saving progress:', currentProgress);
             this.saveToLocalStorage(currentProgress);
         } catch (error) {
-            console.warn('Auto-save failed:', error);
+            logger.warn(CATEGORIES.PROGRESS, 'Auto-save failed', { error: error.message });
         }
     }
 
@@ -356,11 +354,11 @@ class ProgressSystem {
                 setChallengeMode(false);
                 setChallengeScoreValue(0);
             } catch (error) {
-                console.warn('Failed to clear game state:', error);
+                logger.warn(CATEGORIES.PROGRESS, 'Failed to clear game state', { error: error.message });
             }
             
             return { success: true, message: 'Progress cleared successfully' };
-        } catch (error) {
+        } catch {
             return { success: false, message: 'Failed to clear progress' };
         }
     }
@@ -370,20 +368,11 @@ class ProgressSystem {
      * @returns {Object} Progress summary
      */
     getProgressSummary() {
-        console.log('🔍 DEBUG: ProgressSystem.getProgressSummary() called!');
-        console.log('🔍 DEBUG: getProgressSummary - getChallengeScoreValue function:', getChallengeScoreValue);
-        console.log('🔍 DEBUG: getProgressSummary - typeof getChallengeScoreValue:', typeof getChallengeScoreValue);
         
         const challengePoints = getChallengeScoreValue();
-        console.log('🔍 DEBUG: getProgressSummary - challengePoints:', challengePoints);
-        console.log('🔍 DEBUG: getProgressSummary - getChallengeScoreValue():', getChallengeScoreValue());
-        console.log('🔍 DEBUG: getProgressSummary - typeof challengePoints:', typeof challengePoints);
-        console.log('🔍 DEBUG: getProgressSummary - challengePoints === undefined:', challengePoints === undefined);
-        console.log('🔍 DEBUG: getProgressSummary - challengePoints === null:', challengePoints === null);
         
         // Ensure we always return a number
         const safeChallengePoints = (challengePoints !== undefined && challengePoints !== null) ? challengePoints : 0;
-        console.log('🔍 DEBUG: getProgressSummary - safeChallengePoints:', safeChallengePoints);
         
         const result = {
             currentLevel: getCurrentLevel(),
@@ -394,7 +383,6 @@ class ProgressSystem {
             lastSaved: this.getLastSavedTime()
         };
         
-        console.log('🔍 DEBUG: getProgressSummary - returning result:', result);
         return result;
     }
 
@@ -410,7 +398,7 @@ class ProgressSystem {
                 return new Date(data.timestamp).toLocaleString();
             }
         } catch (error) {
-            console.warn('Failed to get last saved time:', error);
+            logger.warn(CATEGORIES.STORAGE, 'Failed to get last saved time', { error: error.message });
         }
         return 'Never';
     }

--- a/js/sharing-system.js
+++ b/js/sharing-system.js
@@ -1,8 +1,7 @@
 // VIM Master Game - Social Media Sharing System
 
-import { 
-    getBadges, getPracticedCommands, getCurrentLevel, getChallengeMode
-} from './game-state.js';
+import { getBadges, getPracticedCommands, getCurrentLevel } from './game-state.js';
+import { logger, CATEGORIES } from './logger.js';
 
 import { exportProgress } from './progress-system.js';
 import { levels } from './levels.js';
@@ -192,7 +191,7 @@ class VimMasterSharingSystem {
             link.href = canvas.toDataURL();
             link.click();
         } catch (error) {
-            console.error('Failed to download achievement card:', error);
+            logger.error(CATEGORIES.UI, 'Failed to download achievement card', { error: error.message });
         }
     }
     
@@ -209,7 +208,7 @@ class VimMasterSharingSystem {
                 this.shareAchievement(achievement, platform);
             }
         } catch (error) {
-            console.error('Failed to share achievement card:', error);
+            logger.error(CATEGORIES.UI, 'Failed to share achievement card', { error: error.message });
         }
     }
     
@@ -221,9 +220,8 @@ class VimMasterSharingSystem {
                 'image/png': blob
             });
             await navigator.clipboard.write([clipboardItem]);
-            console.log('Achievement card copied to clipboard!');
         } catch (error) {
-            console.error('Failed to copy to clipboard:', error);
+            logger.error(CATEGORIES.UI, 'Failed to copy achievement card to clipboard', { error: error.message });
             // Fallback to download
             this.downloadAchievementCard(achievement);
         }
@@ -813,8 +811,8 @@ class VimMasterSharingSystem {
     async nativeShare(shareData) {
         try {
             await navigator.share(shareData);
-        } catch (error) {
-            console.log('Share cancelled or failed:', error);
+        } catch {
+            // User cancelled the native share sheet — not an error
         }
     }
     

--- a/js/ui-components.js
+++ b/js/ui-components.js
@@ -1,8 +1,8 @@
 // VIM Master Game - UI Components (Updated)
 
 import { escapeHtml, getSearchMatches, getLastSearchQuery } from './game-state.js';
+import { logger, CATEGORIES } from './logger.js';
 // Static imports for core dependencies to avoid performance overhead
-import * as challengesModule from './challenges.js';
 import * as levelsModule from './levels.js';
 import * as gameStateModule from './game-state.js';
 
@@ -186,15 +186,13 @@ export function updateInstructions(customText) {
             }
         }
     }).catch(err => {
-        console.error("Error updating instructions", err);
+        logger.error(CATEGORIES.UI, 'Error updating instructions', { error: err.message });
     });
 }
 
 // Level Indicator Updates
 export function updateLevelIndicator(currentLevel, totalLevels) {
-    console.log('🔍 DEBUG: updateLevelIndicator called with:', { currentLevel, totalLevels });
     if (!levelIndicator) {
-        console.log('🔍 DEBUG: levelIndicator element not found!');
         return;
     }
     levelIndicator.textContent = `Level: ${currentLevel + 1} / ${totalLevels}`;
@@ -251,7 +249,6 @@ export function initOnboarding() {
 }
 
 export function progressiveUnlocking(currentLevel) {
-    const progressToggle = document.getElementById('progress-toggle');
     const profileBtn = document.getElementById('profile-btn');
     const practiceArena = document.getElementById('challenge-toggle');
     const cheatHints = document.getElementById('cheat-hints');

--- a/js/vim-commands.js
+++ b/js/vim-commands.js
@@ -1,18 +1,19 @@
 // VIM Master Game - Vim Command Handling
 
-import { 
-    getContent, getCursor, getMode, getCurrentLevel, getCommandHistory, getCommandLog, getYankedLine,
-    getReplacePending, getCountBuffer, getUndoStack, getRedoStack, getLevel12Undo,
-    getLevel12RedoAfterUndo, getLastExCommand, getSearchMode, getSearchQuery,
+import {
+    getContent, getCursor, getMode, getCurrentLevel,
+    getCommandHistory, getYankedLine, getReplacePending, getCountBuffer,
+    getRedoStack, getLevel12Undo, getSearchMode, getSearchQuery,
     getLastSearchQuery, getLastSearchDirection, getSearchMatches, getCurrentMatchIndex,
-    getUsedSearchInLevel, getNavCountSinceSearch, pushUndo, isEscapeKey,
-    setMode, setSearchMode, setCursorRow, setCursorCol, setContent, setYankedLine,
-    setCommandHistory, setCommandLog, setReplacePending, setLevel12Undo, setLevel12RedoAfterUndo,
+    getNavCountSinceSearch, pushUndo, isEscapeKey, setMode,
+    setSearchMode, setCursorRow, setCursorCol, setContent,
+    setYankedLine, setReplacePending, setLevel12Undo, setLevel12RedoAfterUndo,
     setUsedSearchInLevel, setNavCountSinceSearch, setCurrentMatchIndex, setSearchMatches,
     setLastSearchQuery, setLastSearchDirection, setSearchQuery, updateContentLine,
     removeContentLine, insertContentLine, addContentLine, appendCommandHistory,
-    appendCommandLog, clearCommandHistory, clearCommandLog, popUndo, pushRedo,
-    setCountBuffer, setCountBufferAppend, setLastExCommand, addPracticedCommand
+    appendCommandLog, clearCommandHistory, clearCommandLog, popUndo,
+    pushRedo, setCountBuffer, setCountBufferAppend, setLastExCommand,
+    addPracticedCommand
 } from './game-state.js';
 
 import { levels } from './levels.js';
@@ -33,30 +34,22 @@ export function handleNormalMode(e) {
     e.preventDefault();
     const key = e.key;
     const ctrlKey = e.ctrlKey;
-    const shiftKey = e.shiftKey;
-    const altKey = e.altKey;
     
     // Get current state
     let content = getContent();
     let cursor = getCursor();
     let mode = getMode();
     let commandHistory = getCommandHistory();
-    let commandLog = getCommandLog();
     let countBuffer = getCountBuffer();
     let replacePending = getReplacePending();
-    let searchMode = getSearchMode();
-    let searchQuery = getSearchQuery();
     let lastSearchQuery = getLastSearchQuery();
     let lastSearchDirection = getLastSearchDirection();
     let searchMatches = getSearchMatches();
     let currentMatchIndex = getCurrentMatchIndex();
-    let usedSearchInLevel = getUsedSearchInLevel();
     let navCountSinceSearch = getNavCountSinceSearch();
     let yankedLine = getYankedLine();
-    let undoStack = getUndoStack();
     let redoStack = getRedoStack();
     let level12Undo = getLevel12Undo();
-    let level12RedoAfterUndo = getLevel12RedoAfterUndo();
     let currentLevel = getCurrentLevel();
     
     // Count buffer

--- a/scripts/migrate-lessons.js
+++ b/scripts/migrate-lessons.js
@@ -27,7 +27,7 @@ function migrate() {
     };
 
     // 1. Regular Lessons
-    levels.forEach((level, index) => {
+    levels.forEach((level) => {
         const slug = 'lesson-' + toSlug(level.name);
         indexData.regularLessons.push(slug);
 

--- a/tests/regressions/lesson-start-position.regression.test.js
+++ b/tests/regressions/lesson-start-position.regression.test.js
@@ -80,9 +80,11 @@ describe('Regression: TD-0002 Lesson Start Position', () => {
         expect(currentCursor.row).toBe(1);
         expect(currentCursor.col).toBe(fixture.initialContent[1].length - 1);
         
-        // Should warn that clamping occurred
+        // Should warn that clamping occurred (via the structured logger,
+        // which passes metadata as a second console argument)
         expect(console.warn).toHaveBeenCalledWith(
-            expect.stringContaining('is outside the buffer — clamped to')
+            expect.stringContaining('is outside the buffer — clamped to'),
+            expect.anything()
         );
     });
 });

--- a/tests/regressions/lesson-start-position.regression.test.js
+++ b/tests/regressions/lesson-start-position.regression.test.js
@@ -27,11 +27,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { loadFixture } from '../helpers/fixtures.js';
 import { initializeLessonState } from '../../js/levels.js';
 import { getCursor } from '../../js/game-state.js';
+import { logger } from '../../js/logger.js';
 
 describe('Regression: TD-0002 Lesson Start Position', () => {
     let originalConsoleWarn;
 
     beforeEach(() => {
+        // Force the logger's production console format — the singleton
+        // auto-detects "development" from hostname/localStorage, which
+        // differs between local Node and CI. In development format, warns
+        // with metadata go through console.group, not console.warn, and
+        // this test's spy would see nothing.
+        logger.configure({ development: false });
         originalConsoleWarn = console.warn;
         console.warn = vi.fn();
     });

--- a/tests/regressions/practice-mode-lookup.regression.test.js
+++ b/tests/regressions/practice-mode-lookup.regression.test.js
@@ -1,0 +1,64 @@
+/**
+ * Regression ID: practice-mode-lookup (found during TD-11 hygiene review)
+ *
+ * Issue: every "Practice" button in Cheat Mode silently did nothing.
+ *
+ * Original Cause: the content extraction turned `vimLessons` from a plain
+ * object into a `Map`, but the lookup in `startCheatPractice` kept using
+ * bracket access (`vimLessons[item.id]`). Property access on a Map does not
+ * read entries, so the lesson was always `undefined` and the function
+ * returned early — no error, no lesson, nothing.
+ *
+ * User Impact: the entire Cheat Mode practice feature was dead: clicking any
+ * command's Practice button closed nothing, loaded nothing, and gave no
+ * feedback.
+ *
+ * Test Strategy:
+ * 1. Every command in the cheat-sheet catalog must resolve to a practice
+ *    lesson through the same lookup the UI uses.
+ * 2. Starting a practice session must actually enter practice mode and load
+ *    the lesson buffer into game state.
+ *
+ * Never Break Again: the lookup is exercised end-to-end here; a future
+ * container change that breaks resolution fails these tests immediately.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    commandCatalog, getPracticeLesson, startCheatPractice,
+    isInPracticeMode, exitPracticeMode
+} from '../../js/cheat-mode.js';
+import { resetGameState, getContent, setContent, setCursor, setMode } from '../../js/game-state.js';
+
+describe('Regression: Cheat Mode practice lookup', () => {
+    beforeEach(() => {
+        exitPracticeMode();
+        resetGameState();
+        setContent(['placeholder line']);
+        setCursor({ row: 0, col: 0 });
+        setMode('NORMAL');
+    });
+
+    it('resolves a practice lesson for every catalog entry', () => {
+        for (const group of commandCatalog) {
+            for (const item of group.items) {
+                const lesson = getPracticeLesson(item.id);
+                expect(lesson, `catalog entry '${item.id}' has no practice lesson`).toBeTruthy();
+                expect(Array.isArray(lesson.initialContent)).toBe(true);
+            }
+        }
+    });
+
+    it('startCheatPractice enters practice mode and loads the lesson buffer', () => {
+        const item = commandCatalog[0].items[0]; // hjkl
+        const lesson = getPracticeLesson(item.id);
+
+        startCheatPractice(item);
+
+        expect(isInPracticeMode()).toBe(true);
+        expect(getContent()).toEqual(lesson.initialContent);
+
+        exitPracticeMode();
+        expect(isInPracticeMode()).toBe(false);
+    });
+});


### PR DESCRIPTION
## What does this PR do?

The TD-11 hygiene sweep, plus one real bug it uncovered. Top of the stack (#20 → #21 → #22 → #23 → this). Two commits, reviewable separately.

## Commit 1 — fix: Cheat Mode practice buttons were dead

### Root cause
- **Problem:** clicking any Practice button in Cheat Mode silently did nothing — the entire practice feature was dead.
- **Root cause:** the content extraction turned `vimLessons` into a `Map`, but the lookup kept using `vimLessons[item.id]` — property access on a Map reads nothing, so the lesson was always `undefined` and the function returned early with no signal.
- **Solution:** `Map.get` via a named `getPracticeLesson()`, with a logged warning when resolution fails.
- **Why this happened:** a container type changed without its access sites; nothing exercised the click path.
- **How we prevent this forever:** end-to-end regression tests — every cheat-sheet catalog entry must resolve to a lesson, and `startCheatPractice` must actually enter practice mode and load the buffer.

## Commit 2 — chore: TD-11 hygiene

- **~110 debug `console.log`s deleted** (several dumped full buffer state per keystroke); meaningful warnings/errors now flow through the structured logger (`js/logger.js`) with categories and `localStorage.vimMasterDebug` filtering.
- **195 lint warnings → 0**: ~170 unused imports/variables removed (codemod driven by the ESLint API), empty blocks and unused catch bindings cleaned.
- **Rules promoted to CI-enforced errors** so none of it can return: `no-console` (logger/scripts/tests exempt), `no-unused-vars`, `no-empty`, `no-debugger`.

## How was it verified?

- lint exits 0 with **zero** findings under the strict rules
- content 35 bundled · contract 0/0 · golden 35/35 · unit+regression **21/21** (2 new)
- in-browser: 'dd' practice card loads its lesson + overlay; browser console completely silent from app code (only the known Tailwind CDN warning, TD-10)

- [x] This PR is hygiene + the one bug the hygiene uncovered, nothing else
- [x] Save-data format unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)