### PR TITLE
fix: undo no longer crosses editing sessions (#12, #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: se
 - **Tailwind is now built, not fetched** (TD-10): the ~300 KB render-blocking `cdn.tailwindcss.com` script (explicitly not for production) is replaced by a 32 KB static `css/tailwind.css` generated at build time from the classes actually used (`npm run build:css`, Tailwind v3 — same major as the CDN, guaranteeing visual parity). Wired into `npm run check`/CI; the last third-party console warning is gone, and offline/PWA work is unblocked.
 
 ### Fixed
+- **Undo no longer crosses editing sessions** (issues [#12](https://github.com/renzorlive/vimmaster/issues/12), [#6](https://github.com/renzorlive/vimmaster/issues/6)): `resetLevelState()` didn't clear the undo/redo stacks, so pressing `u` on a freshly-loaded level (or after entering Challenge Mode) restored the *previous* buffer while the UI stayed put. The stacks are now cleared on level load and challenge entry. Regression-tested.
 - **Practice lessons are validated again**: the contract runner iterated the `vimLessons` Map with `Object.entries()` (always empty), silently skipping all 17 practice lessons — the suite now checks all 35 lessons instead of 18. Same Map-migration bug family as the dead Practice buttons fixed in v3.0.0.
 
 ## [3.0.0] - 2026-07-10 — Community Alpha

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -119,7 +119,14 @@ export const startChallenge = (gameState, challengeIndex = null) => {
     if (gameState.currentChallenge) {
         return;
     }
-    
+
+    // Fresh editing session: clear undo/redo (and search/command state) so
+    // pressing `u` in a challenge can't restore the buffer the player was on
+    // before entering it (issue #6).
+    if (gameState.resetLevelState) {
+        gameState.resetLevelState();
+    }
+
     // Select a random challenge if none specified
     if (challengeIndex === null) {
         challengeIndex = Math.floor(Math.random() * challenges.length);

--- a/js/game-state.js
+++ b/js/game-state.js
@@ -273,6 +273,11 @@ export const resetLevelState = () => {
     _commandHistory = '';
     _commandLog = [];
     _yankedLine = null;
+    // Undo/redo history belongs to a single editing session. Without this,
+    // pressing `u` on a freshly-loaded level (or challenge task) restored
+    // the PREVIOUS level's buffer while the UI stayed put (issues #12, #6).
+    _undoStack = [];
+    _redoStack = [];
 };
 
 // Content manipulation functions

--- a/tests/regressions/undo-crosses-levels.regression.test.js
+++ b/tests/regressions/undo-crosses-levels.regression.test.js
@@ -1,0 +1,88 @@
+/**
+ * Regression IDs: #12 and #6 (undo history crosses editing sessions)
+ *
+ * Issue #12: completing a level and pressing `u` on the next level restored
+ * the PREVIOUS level's buffer while the UI stayed on the new level.
+ *
+ * Issue #6: entering Challenge Mode and mis-hitting `u` restored the buffer
+ * the player was on before the challenge.
+ *
+ * Original Cause: `resetLevelState()` (called by `loadLevel`) cleared search
+ * and command state but NOT `_undoStack`/`_redoStack`, and the challenge
+ * start path never reset per-session state at all. Undo snapshots from one
+ * editing session survived into the next.
+ *
+ * User Impact: `u` could silently replace the current lesson's buffer with an
+ * unrelated one, desyncing the visible editor from the win check.
+ *
+ * Never Break Again: undo/redo stacks are cleared in `resetLevelState()`
+ * (level loads) and `startChallenge()` calls it (challenge entry).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { handleNormalMode } from '../../js/vim-commands.js';
+import { loadLevel, levels } from '../../js/levels.js';
+import { startChallenge, challenges } from '../../js/challenges.js';
+import {
+    resetGameState, getContent, getUndoStack,
+    setContent, setCursor, setMode,
+    resetLevelState, setCurrentChallenge, setCurrentTaskIndex,
+    setChallengeScoreValue, setChallengeProgressValue, setChallengeStartTime
+} from '../../js/game-state.js';
+
+const press = (key, opts = {}) =>
+    handleNormalMode({ key, preventDefault: () => {}, ctrlKey: false, altKey: false, shiftKey: false, ...opts });
+
+describe('Regression #12: undo does not cross level boundaries', () => {
+    beforeEach(() => resetGameState());
+
+    it('after loading a new level, the undo stack is empty', () => {
+        // Find a level that pushes undo on edit (dd / x etc. via a target-content lesson)
+        const editIndex = levels.findIndex((l) => l.targetContent);
+        loadLevel(editIndex);
+        // Make an edit to populate the undo stack
+        press('d'); press('d');
+        expect(getUndoStack().length).toBeGreaterThan(0);
+
+        // Move to another level
+        const other = (editIndex + 1) % levels.length;
+        loadLevel(other);
+        expect(getUndoStack().length).toBe(0);
+    });
+
+    it('pressing u on a freshly loaded level does not change its buffer', () => {
+        const editIndex = levels.findIndex((l) => l.targetContent);
+        loadLevel(editIndex);
+        press('d'); press('d'); // edit level A
+
+        const other = (editIndex + 1) % levels.length;
+        loadLevel(other);
+        const bufferBefore = JSON.stringify(getContent());
+        press('u'); // must be a no-op, not a restore of level A
+        expect(JSON.stringify(getContent())).toBe(bufferBefore);
+    });
+});
+
+describe('Regression #6: entering a challenge clears prior undo history', () => {
+    beforeEach(() => resetGameState());
+
+    it('undo stack is empty right after a challenge starts', () => {
+        // Populate an undo stack in a normal level first
+        const editIndex = levels.findIndex((l) => l.targetContent);
+        loadLevel(editIndex);
+        press('d'); press('d');
+        expect(getUndoStack().length).toBeGreaterThan(0);
+
+        // Enter a challenge through the same object shape event-handlers uses
+        const gameState = {
+            resetLevelState,
+            setContent, setCursor, setMode,
+            setCurrentChallenge, setCurrentTaskIndex,
+            setChallengeScoreValue, setChallengeProgressValue, setChallengeStartTime
+        };
+        startChallenge(gameState, 0);
+
+        expect(getUndoStack().length).toBe(0);
+        expect(getContent()).toEqual(challenges[0].initialContent);
+    });
+});


### PR DESCRIPTION
## What does this PR do?
Fixes two long-standing undo bugs with one root cause. **Base of a 3-PR stack** (A → B → C).

## Root cause
- **Problem:** pressing `u` on a freshly-loaded level restored the *previous* level's buffer while the UI stayed put (#12); mis-hitting `u` after entering Challenge Mode restored the pre-challenge buffer (#6).
- **Root cause:** `resetLevelState()` cleared search/command state but **not** `_undoStack`/`_redoStack`, and the challenge-start path reset no per-session state at all. Undo snapshots leaked across editing sessions.
- **Solution:** `resetLevelState()` now clears both stacks (`loadLevel` calls it); `startChallenge()` calls `resetLevelState()` on entry.
- This is exactly the fix `iserioton` diagnosed in the #6 thread back in September.

## How was it verified?
3 regression tests (stack empty after level load; `u` is a no-op on a fresh level; challenge entry clears the stack) + real-runtime browser check (edit → stack=1, load next → stack=0, `u` does nothing).

Fixes #12, fixes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)