### PR TITLE
feat: add ^ and WORD motions W/B/E (#5, #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: se
 ## [Unreleased]
 
 ### Added
+- **New motions: `^` and the WORD family `W`/`B`/`E`** (issues [#5](https://github.com/renzorlive/vimmaster/issues/5), [#7](https://github.com/renzorlive/vimmaster/issues/7)). `^` jumps to the first non-blank character of the line; `W`/`B`/`E` move by whitespace-delimited WORDs (punctuation stays attached, unlike `w`/`b`/`e`). Counts supported (`3W`); 9 new unit tests.
 - **Two-tier content validator** (issue #26): per-lesson schema rules now also check `initialCursor` within buffer bounds and validate every `solution` key token; a new repository-wide semantic pass catches what per-file validation can't — duplicate lesson IDs (S001), dangling `prerequisites` references (S002), duplicate curriculum order (S003), and index/content drift in both directions (S004). Every violation is reported with `file path → schema location`, all in one run. 14 new tests cover every violation class.
 
 ### Changed

--- a/js/vim-commands.js
+++ b/js/vim-commands.js
@@ -257,6 +257,13 @@ export function handleNormalMode(e) {
     }
     if (key === '0') { setCursorCol(0); }
     if (key === '$') { const line = content[cursor.row]; setCursorCol(Math.max(0, line.length - 1)); }
+    if (key === '^') {
+        // First non-blank character of the line (issue #5)
+        addPracticedCommand('caret_first_nonblank');
+        const line = content[cursor.row];
+        const idx = line.search(/\S/);
+        setCursorCol(idx === -1 ? 0 : idx);
+    }
 
     // Word movement
     // Avoid moving on 'w' when it's part of operators like 'dw' or 'cw'
@@ -294,6 +301,49 @@ export function handleNormalMode(e) {
             while (i < line.length && !isWordChar(line[i])) { i++; }
             while (i < line.length - 1 && isWordChar(line[i + 1])) { i++; }
             if (isWordChar(line[i])) { setCursorCol(i); }
+        });
+    }
+
+    // WORD movement (whitespace-delimited — capital W/B/E, issue #7).
+    // WORDs break only on whitespace, so punctuation stays attached, unlike
+    // lowercase w/b/e above.
+    const isSpace = (ch) => ch === undefined || /\s/.test(ch);
+    if (key === 'W') {
+        addPracticedCommand('W_WORD_forward');
+        repeat(count, () => {
+            const c = getCursor();
+            const line = content[c.row];
+            let i = c.col;
+            while (i < line.length && !isSpace(line[i])) i++;   // past current WORD
+            while (i < line.length && isSpace(line[i])) i++;    // past whitespace
+            if (i < line.length) {
+                setCursorCol(i);
+            } else if (c.row < content.length - 1) {
+                setCursorRow(c.row + 1);
+                setCursorCol(0);
+            }
+        });
+    }
+    if (key === 'B') {
+        addPracticedCommand('B_WORD_backward');
+        repeat(count, () => {
+            const c = getCursor();
+            const line = content[c.row];
+            let i = c.col - 1;
+            while (i >= 0 && isSpace(line[i])) i--;              // back over whitespace
+            while (i > 0 && !isSpace(line[i - 1])) i--;          // to start of WORD
+            setCursorCol(Math.max(0, i));
+        });
+    }
+    if (key === 'E') {
+        addPracticedCommand('E_WORD_end');
+        repeat(count, () => {
+            const c = getCursor();
+            const line = content[c.row];
+            let i = c.col + 1;
+            while (i < line.length && isSpace(line[i])) i++;     // forward to next WORD
+            while (i < line.length - 1 && !isSpace(line[i + 1])) i++; // to end of WORD
+            if (i < line.length) setCursorCol(Math.min(i, line.length - 1));
         });
     }
 

--- a/tests/unit/word-motions.test.js
+++ b/tests/unit/word-motions.test.js
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the caret and WORD motions (issues #5 and #7).
+ *
+ * `^` — first non-blank character of the line.
+ * `W`/`B`/`E` — WORD motions, whitespace-delimited (punctuation stays
+ * attached to the WORD, unlike lowercase w/b/e).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { handleNormalMode } from '../../js/vim-commands.js';
+import { resetGameState, setContent, setCursor, setMode, getCursor } from '../../js/game-state.js';
+
+const press = (key) =>
+    handleNormalMode({ key, preventDefault: () => {}, ctrlKey: false, altKey: false, shiftKey: false });
+const type = (...keys) => keys.forEach(press);
+const col = () => getCursor().col;
+const row = () => getCursor().row;
+
+beforeEach(() => {
+    resetGameState();
+    setMode('NORMAL');
+});
+
+describe('^ — first non-blank character (issue #5)', () => {
+    it('jumps to the first non-blank character', () => {
+        setContent(['    hello world']);
+        setCursor({ row: 0, col: 12 });
+        press('^');
+        expect(col()).toBe(4); // first 'h'
+    });
+
+    it('goes to column 0 on an all-whitespace line', () => {
+        setContent(['      ']);
+        setCursor({ row: 0, col: 3 });
+        press('^');
+        expect(col()).toBe(0);
+    });
+
+    it('stays put when already at the first non-blank', () => {
+        setContent(['  ab']);
+        setCursor({ row: 0, col: 2 });
+        press('^');
+        expect(col()).toBe(2);
+    });
+});
+
+describe('W/B/E — WORD motions keep punctuation attached (issue #7)', () => {
+    // "foo.bar baz qux"
+    //  0123456789...
+    it('W skips over punctuation that w would stop on', () => {
+        setContent(['foo.bar baz qux']);
+        setCursor({ row: 0, col: 0 });
+        press('W');
+        expect(col()).toBe(8); // start of "baz", not the '.' at col 3
+    });
+
+    it('2W jumps two WORDs', () => {
+        setContent(['foo.bar baz qux']);
+        setCursor({ row: 0, col: 0 });
+        type('2', 'W');
+        expect(col()).toBe(12); // start of "qux"
+    });
+
+    it('W crosses to the next line when no WORD remains', () => {
+        setContent(['end', 'next line']);
+        setCursor({ row: 0, col: 1 });
+        press('W');
+        expect(row()).toBe(1);
+        expect(col()).toBe(0);
+    });
+
+    it('E moves to the end of the WORD, treating punctuation as part of it', () => {
+        setContent(['foo.bar baz']);
+        setCursor({ row: 0, col: 0 });
+        press('E');
+        expect(col()).toBe(6); // 'r' — end of "foo.bar"
+    });
+
+    it('B moves back to the start of the WORD', () => {
+        setContent(['foo.bar baz']);
+        setCursor({ row: 0, col: 8 }); // on "baz"
+        press('B');
+        expect(col()).toBe(0); // start of "foo.bar"
+    });
+
+    it('B from mid-WORD goes to that WORD’s start', () => {
+        setContent(['alpha beta.gamma']);
+        setCursor({ row: 0, col: 12 }); // inside "beta.gamma"
+        press('B');
+        expect(col()).toBe(6); // start of "beta.gamma"
+    });
+});


### PR DESCRIPTION
## What does this PR do?
Adds the missing motions requested in #5 and #7. Top of the stack (on #31).

- **`^`** — first non-blank character of the line (#5)
- **`W`/`B`/`E`** — whitespace-delimited WORD motions; punctuation stays attached, unlike `w`/`b`/`e` (#7). Counts supported (`3W`).

Implementations follow the fresh-cursor-per-iteration pattern so counts behave correctly (post-TD-4b).

## How was it verified?
9 new unit tests (`^` incl. all-whitespace & already-at-target; `W` skipping punctuation; `2W`; `W` crossing lines; `E` to WORD end; `B` to WORD start). Full suite 48/48, golden 35/35, contract 0/0, lint 0/0. In-browser via the canonical engine modules: `^`→4, `W`→8→12, `B`→8.

Lessons teaching these can follow as a content PR (good first issue).

Fixes #5, fixes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)