### PR TITLE
Add f/F find-character motion (+ lesson)

### DIFF
--- a/content/index.json
+++ b/content/index.json
@@ -1,13 +1,14 @@
 {
   "version": 1,
   "contentVersion": 1,
-  "generatedAt": "2026-07-10T17:17:01.536Z",
+  "generatedAt": "2026-07-16T00:04:48.351Z",
   "generator": "scripts/build-content.js",
   "regularLessons": [
     "lesson-how-to-exit-ex-commands",
     "lesson-basic-movement",
     "lesson-word-movement",
     "lesson-line-jumps",
+    "lesson-find-char",
     "lesson-insert-mode",
     "lesson-delete-basics",
     "lesson-yank-put-copy-paste",

--- a/content/lessons/lesson-append-and-open-lines.json
+++ b/content/lessons/lesson-append-and-open-lines.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 9
+    "order": 10
   },
   "instructions": "Use a to append after cursor. Use o to open a new line below, and O to open above. Add a new line between the two lines that reads 'Inserted here'.",
   "initialContent": [

--- a/content/lessons/lesson-change-inner-word-ciw.json
+++ b/content/lessons/lesson-change-inner-word-ciw.json
@@ -21,7 +21,7 @@
       "Use 'ciw' to change a word completely without needing to be at its start",
       "Understand how 'c' combines with 'iw'"
     ],
-    "order": 18
+    "order": 19
   },
   "instructions": "Use 'ciw' to change the word 'wrong' into 'right'. Press Esc when done.",
   "initialContent": [

--- a/content/lessons/lesson-change-word-cw.json
+++ b/content/lessons/lesson-change-word-cw.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 10
+    "order": 11
   },
   "instructions": "Use cw to change the word 'bad' into 'good'. Press Esc when done.",
   "initialContent": [

--- a/content/lessons/lesson-counts-move-faster.json
+++ b/content/lessons/lesson-counts-move-faster.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 12
+    "order": 13
   },
   "instructions": "Use a count with motions. Press 3 then w to jump three words and land on 'target'.",
   "initialContent": [

--- a/content/lessons/lesson-delete-basics.json
+++ b/content/lessons/lesson-delete-basics.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 6
+    "order": 7
   },
   "instructions": "Use dd to delete the full middle line. Then use dw to remove the word 'mistake' on the last line. You can use x to delete a single character if needed.",
   "initialContent": [

--- a/content/lessons/lesson-delete-end-replace.json
+++ b/content/lessons/lesson-delete-end-replace.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 11
+    "order": 12
   },
   "instructions": "Use D to delete from cursor to end of line, then use r to replace the 'x' with '!'.",
   "initialContent": [

--- a/content/lessons/lesson-delete-inner-word-diw.json
+++ b/content/lessons/lesson-delete-inner-word-diw.json
@@ -21,7 +21,7 @@
       "Understand the 'iw' (inner word) text object",
       "Use 'diw' to delete a word without needing to be at its start"
     ],
-    "order": 17
+    "order": 18
   },
   "instructions": "Use 'diw' to delete the word 'mistake' from anywhere inside it.",
   "initialContent": [

--- a/content/lessons/lesson-find-char.json
+++ b/content/lessons/lesson-find-char.json
@@ -1,0 +1,36 @@
+{
+  "id": "lesson-find-char",
+  "version": 1,
+  "name": "Find Character (f / F)",
+  "metadata": {
+    "revision": 1,
+    "author": "VIM Master Team",
+    "githubUsername": "vimmaster",
+    "created": "2026-07-15",
+    "difficulty": "beginner",
+    "tags": [
+      "normal"
+    ],
+    "estimatedTime": 60,
+    "prerequisites": [],
+    "learningObjectives": [],
+    "order": 5
+  },
+  "instructions": "Use f<char> to jump forward to the next occurrence of a character on the current line, and F<char> to jump backward. A count repeats it, so 3fx lands on the 3rd 'x'. Move to the 'x' with fx.",
+  "initialContent": [
+    "Find the x on this line using the f motion."
+  ],
+  "target": {
+    "row": 0,
+    "col": 9
+  },
+  "focusCommand": "f / F",
+  "initialCursor": {
+    "row": 0,
+    "col": 0
+  },
+  "solution": [
+    "f",
+    "x"
+  ]
+}

--- a/content/lessons/lesson-insert-mode.json
+++ b/content/lessons/lesson-insert-mode.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 5
+    "order": 6
   },
   "instructions": "Press 'a' to append after the cursor. Type ' is awesome!' and press Esc to return to NORMAL mode.",
   "initialContent": [

--- a/content/lessons/lesson-line-bounds-0-and.json
+++ b/content/lessons/lesson-line-bounds-0-and.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 8
+    "order": 9
   },
   "instructions": "Use 0 to jump to start of line and $ to jump to end. Move to the last character of the first line.",
   "initialContent": [

--- a/content/lessons/lesson-search-backward.json
+++ b/content/lessons/lesson-search-backward.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 15
+    "order": 16
   },
   "instructions": "Press ? then type 'alpha' and Enter, then press N once to jump to the previous occurrence.",
   "initialContent": [

--- a/content/lessons/lesson-search-forward.json
+++ b/content/lessons/lesson-search-forward.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 14
+    "order": 15
   },
   "instructions": "Press / then type 'target' and Enter, then press n once to jump to the next occurrence.",
   "initialContent": [

--- a/content/lessons/lesson-search-navigation-n-n.json
+++ b/content/lessons/lesson-search-navigation-n-n.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 16
+    "order": 17
   },
   "instructions": "Search for 'foo' with /foo then press n twice to reach the third occurrence.",
   "initialContent": [

--- a/content/lessons/lesson-undo-redo.json
+++ b/content/lessons/lesson-undo-redo.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 13
+    "order": 14
   },
   "instructions": "Delete the middle line with dd, undo it with u, then redo with Ctrl+r to finish with the line deleted.",
   "initialContent": [

--- a/content/lessons/lesson-yank-put-copy-paste.json
+++ b/content/lessons/lesson-yank-put-copy-paste.json
@@ -14,7 +14,7 @@
     "estimatedTime": 60,
     "prerequisites": [],
     "learningObjectives": [],
-    "order": 7
+    "order": 8
   },
   "instructions": "Use yy to yank (copy) a line and p to put (paste) it. Duplicate the second line.",
   "initialContent": [

--- a/js/game-state.js
+++ b/js/game-state.js
@@ -9,6 +9,7 @@ let _commandHistory = '';
 let _commandLog = [];
 let _yankedLine = null;
 let _replacePending = false;
+let _pendingFind = null;
 let _countBuffer = '';
 let _undoStack = [];
 let _redoStack = [];
@@ -46,6 +47,7 @@ export const getCommandHistory = () => _commandHistory;
 export const getCommandLog = () => [..._commandLog];
 export const getYankedLine = () => _yankedLine;
 export const getReplacePending = () => _replacePending;
+export const getPendingFind = () => _pendingFind;
 export const getCountBuffer = () => _countBuffer;
 export const getUndoStack = () => [..._undoStack];
 export const getRedoStack = () => [..._redoStack];
@@ -111,6 +113,10 @@ export const setYankedLine = (newYankedLine) => {
 
 export const setReplacePending = (newReplacePending) => {
     _replacePending = newReplacePending;
+};
+
+export const setPendingFind = (newPendingFind) => {
+    _pendingFind = newPendingFind;
 };
 
 export const setCountBuffer = (newCountBuffer) => {
@@ -226,6 +232,7 @@ export const resetGameState = () => {
     _commandLog = [];
     _yankedLine = null;
     _replacePending = false;
+    _pendingFind = null;
     _countBuffer = '';
     _undoStack = [];
     _redoStack = [];
@@ -259,6 +266,7 @@ export const resetChallengeState = () => {
 };
 
 export const resetLevelState = () => {
+    _pendingFind = null;
     _level12Undo = false;
     _level12RedoAfterUndo = false;
     _lastExCommand = null;

--- a/js/generated-content.js
+++ b/js/generated-content.js
@@ -9,13 +9,14 @@ export const generatedContent = {
   "index": {
     "version": 1,
     "contentVersion": 1,
-    "generatedAt": "2026-07-10T17:17:01.536Z",
+    "generatedAt": "2026-07-16T00:04:48.351Z",
     "generator": "scripts/build-content.js",
     "regularLessons": [
       "lesson-how-to-exit-ex-commands",
       "lesson-basic-movement",
       "lesson-word-movement",
       "lesson-line-jumps",
+      "lesson-find-char",
       "lesson-insert-mode",
       "lesson-delete-basics",
       "lesson-yank-put-copy-paste",
@@ -223,6 +224,42 @@ export const generatedContent = {
         "l"
       ]
     },
+    "lesson-find-char": {
+      "id": "lesson-find-char",
+      "version": 1,
+      "name": "Find Character (f / F)",
+      "metadata": {
+        "revision": 1,
+        "author": "VIM Master Team",
+        "githubUsername": "vimmaster",
+        "created": "2026-07-15",
+        "difficulty": "beginner",
+        "tags": [
+          "normal"
+        ],
+        "estimatedTime": 60,
+        "prerequisites": [],
+        "learningObjectives": [],
+        "order": 5
+      },
+      "instructions": "Use f<char> to jump forward to the next occurrence of a character on the current line, and F<char> to jump backward. A count repeats it, so 3fx lands on the 3rd 'x'. Move to the 'x' with fx.",
+      "initialContent": [
+        "Find the x on this line using the f motion."
+      ],
+      "target": {
+        "row": 0,
+        "col": 9
+      },
+      "focusCommand": "f / F",
+      "initialCursor": {
+        "row": 0,
+        "col": 0
+      },
+      "solution": [
+        "f",
+        "x"
+      ]
+    },
     "lesson-insert-mode": {
       "id": "lesson-insert-mode",
       "version": 1,
@@ -239,7 +276,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 5
+        "order": 6
       },
       "instructions": "Press 'a' to append after the cursor. Type ' is awesome!' and press Esc to return to NORMAL mode.",
       "initialContent": [
@@ -291,7 +328,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 6
+        "order": 7
       },
       "instructions": "Use dd to delete the full middle line. Then use dw to remove the word 'mistake' on the last line. You can use x to delete a single character if needed.",
       "initialContent": [
@@ -334,7 +371,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 7
+        "order": 8
       },
       "instructions": "Use yy to yank (copy) a line and p to put (paste) it. Duplicate the second line.",
       "initialContent": [
@@ -377,7 +414,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 8
+        "order": 9
       },
       "instructions": "Use 0 to jump to start of line and $ to jump to end. Move to the last character of the first line.",
       "initialContent": [
@@ -413,7 +450,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 9
+        "order": 10
       },
       "instructions": "Use a to append after cursor. Use o to open a new line below, and O to open above. Add a new line between the two lines that reads 'Inserted here'.",
       "initialContent": [
@@ -464,7 +501,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 10
+        "order": 11
       },
       "instructions": "Use cw to change the word 'bad' into 'good'. Press Esc when done.",
       "initialContent": [
@@ -505,7 +542,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 11
+        "order": 12
       },
       "instructions": "Use D to delete from cursor to end of line, then use r to replace the 'x' with '!'.",
       "initialContent": [
@@ -545,7 +582,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 12
+        "order": 13
       },
       "instructions": "Use a count with motions. Press 3 then w to jump three words and land on 'target'.",
       "initialContent": [
@@ -581,7 +618,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 13
+        "order": 14
       },
       "instructions": "Delete the middle line with dd, undo it with u, then redo with Ctrl+r to finish with the line deleted.",
       "initialContent": [
@@ -621,7 +658,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 14
+        "order": 15
       },
       "instructions": "Press / then type 'target' and Enter, then press n once to jump to the next occurrence.",
       "initialContent": [
@@ -667,7 +704,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 15
+        "order": 16
       },
       "instructions": "Press ? then type 'alpha' and Enter, then press N once to jump to the previous occurrence.",
       "initialContent": [
@@ -711,7 +748,7 @@ export const generatedContent = {
         "estimatedTime": 60,
         "prerequisites": [],
         "learningObjectives": [],
-        "order": 16
+        "order": 17
       },
       "instructions": "Search for 'foo' with /foo then press n twice to reach the third occurrence.",
       "initialContent": [
@@ -761,7 +798,7 @@ export const generatedContent = {
           "Understand the 'iw' (inner word) text object",
           "Use 'diw' to delete a word without needing to be at its start"
         ],
-        "order": 17
+        "order": 18
       },
       "instructions": "Use 'diw' to delete the word 'mistake' from anywhere inside it.",
       "initialContent": [
@@ -804,7 +841,7 @@ export const generatedContent = {
           "Use 'ciw' to change a word completely without needing to be at its start",
           "Understand how 'c' combines with 'iw'"
         ],
-        "order": 18
+        "order": 19
       },
       "instructions": "Use 'ciw' to change the word 'wrong' into 'right'. Press Esc when done.",
       "initialContent": [

--- a/js/vim-commands.js
+++ b/js/vim-commands.js
@@ -2,12 +2,12 @@
 
 import {
     getContent, getCursor, getMode, getCurrentLevel,
-    getCommandHistory, getYankedLine, getReplacePending, getCountBuffer,
+    getCommandHistory, getYankedLine, getReplacePending, getPendingFind, getCountBuffer,
     getRedoStack, getLevel12Undo, getSearchMode, getSearchQuery,
     getLastSearchQuery, getLastSearchDirection, getSearchMatches, getCurrentMatchIndex,
     getNavCountSinceSearch, getXp, getCombo, pushUndo, isEscapeKey, setMode,
     setSearchMode, setCursorRow, setCursorCol, setContent,
-    setYankedLine, setReplacePending, setLevel12Undo, setLevel12RedoAfterUndo,
+    setYankedLine, setReplacePending, setPendingFind, setLevel12Undo, setLevel12RedoAfterUndo,
     setUsedSearchInLevel, setNavCountSinceSearch, setCurrentMatchIndex, setSearchMatches,
     setLastSearchQuery, setLastSearchDirection, setSearchQuery, updateContentLine,
     removeContentLine, insertContentLine, addContentLine, appendCommandHistory,
@@ -28,6 +28,20 @@ const repeat = (count, action) => {
 
 // Check if character is a word character
 const isWordChar = (char) => /\w/.test(char);
+
+// Find the column of the Nth occurrence of `target` on a single line,
+// searching from `col` in `direction` (1 = forward / f, -1 = backward / F).
+// The current column is excluded, matching Vim; returns -1 when not found
+// so the caller leaves the cursor where it is.
+const findCharColumn = (line, col, target, direction, count) => {
+    let remaining = count;
+    for (let i = col + direction; i >= 0 && i < line.length; i += direction) {
+        if (line[i] === target && --remaining === 0) {
+            return i;
+        }
+    }
+    return -1;
+};
 
 // Handle Normal Mode Commands
 export function handleNormalMode(e) {
@@ -52,6 +66,37 @@ export function handleNormalMode(e) {
     let level12Undo = getLevel12Undo();
     let currentLevel = getCurrentLevel();
     
+    // Consume the target of a pending find-character motion (f/F). This runs
+    // before the count-buffer handling so a digit target (e.g. `f3`) is taken
+    // as the character to find rather than as a count.
+    let pendingFind = getPendingFind();
+    if (pendingFind) {
+        // Ignore modifier keys while waiting for the target character.
+        if (key === 'Shift' || key === 'Control' || key === 'Alt' || key === 'Meta') {
+            return;
+        }
+        // Escape cancels the pending motion without moving the cursor.
+        if (isEscapeKey(e)) {
+            setPendingFind(null);
+            return;
+        }
+        if (key.length === 1) {
+            const line = content[cursor.row] || '';
+            const findCount = countBuffer ? Math.max(1, parseInt(countBuffer, 10)) : 1;
+            const targetCol = findCharColumn(line, cursor.col, key, pendingFind.direction, findCount);
+            if (targetCol !== -1) {
+                setCursorCol(targetCol);
+                addPracticedCommand(pendingFind.direction === 1 ? 'f_find_forward' : 'F_find_backward');
+            }
+            setPendingFind(null);
+            setCountBuffer('');
+            clearCommandLog();
+            return;
+        }
+        // Any other non-printable key: keep waiting for a target.
+        return;
+    }
+
     // Count buffer
     if (/^[0-9]$/.test(key)) {
         if (!(key === '0' && countBuffer === '')) {
@@ -123,6 +168,14 @@ export function handleNormalMode(e) {
     // Start single-char replace immediately so it doesn't get logged in command history
     if (key === 'r' && !replacePending) {
         setReplacePending(true);
+        clearCommandLog();
+        return;
+    }
+
+    // Start a find-character motion (f/F) immediately so the trigger key is
+    // not logged in command history; the next key is consumed as the target.
+    if ((key === 'f' || key === 'F') && !pendingFind) {
+        setPendingFind({ direction: key === 'f' ? 1 : -1 });
         clearCommandLog();
         return;
     }

--- a/scripts/inject-order.js
+++ b/scripts/inject-order.js
@@ -8,6 +8,7 @@ const orderedRegular = [
     "lesson-basic-movement",
     "lesson-word-movement",
     "lesson-line-jumps",
+    "lesson-find-char",
     "lesson-insert-mode",
     "lesson-delete-basics",
     "lesson-yank-put-copy-paste",

--- a/tests/unit/find-char.test.js
+++ b/tests/unit/find-char.test.js
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for the f/F find-character motion (issue #36).
+ *
+ * f<char> moves the cursor forward to the next occurrence of <char> on the
+ * current line; F<char> moves backward to the previous occurrence. The current
+ * column is excluded (Vim behavior), counts repeat the motion, a missing
+ * character leaves the cursor put, and Esc cancels the pending motion.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { handleNormalMode } from '../../js/vim-commands.js';
+import {
+    resetGameState, setContent, setCursor, setMode,
+    getCursor
+} from '../../js/game-state.js';
+
+const press = (key, opts = {}) => {
+    handleNormalMode({
+        key,
+        preventDefault: () => {},
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        ...opts
+    });
+};
+
+const type = (...keys) => keys.forEach((k) => press(k));
+
+describe('f/F find-character motion', () => {
+    beforeEach(() => {
+        resetGameState();
+        setMode('NORMAL');
+    });
+
+    it('fx moves forward to the next x', () => {
+        setContent(['abxcdxe']); // x at cols 2 and 5
+        setCursor({ row: 0, col: 0 });
+        type('f', 'x');
+        expect(getCursor().col).toBe(2);
+    });
+
+    it('fx does not move when the character is absent', () => {
+        setContent(['abcdef']);
+        setCursor({ row: 0, col: 0 });
+        type('f', 'x');
+        expect(getCursor().col).toBe(0);
+    });
+
+    it('fx searches after the cursor, skipping the current column', () => {
+        setContent(['xabxc']); // cursor starts on the x at col 0
+        setCursor({ row: 0, col: 0 });
+        type('f', 'x');
+        expect(getCursor().col).toBe(3); // jumps to the next x, not the one under the cursor
+    });
+
+    it('Fx moves backward to the previous x', () => {
+        setContent(['axbxcd']); // x at cols 1 and 3
+        setCursor({ row: 0, col: 5 });
+        type('F', 'x');
+        expect(getCursor().col).toBe(3);
+    });
+
+    it('Fx does not move when there is no earlier x', () => {
+        setContent(['abcxd']); // the only x is ahead of the cursor
+        setCursor({ row: 0, col: 2 });
+        type('F', 'x');
+        expect(getCursor().col).toBe(2);
+    });
+
+    it('3fx jumps to the 3rd occurrence', () => {
+        setContent(['xaxbxcxdx']); // x at cols 0,2,4,6,8
+        setCursor({ row: 0, col: 0 });
+        type('3', 'f', 'x');
+        expect(getCursor().col).toBe(6); // 3rd x after col 0 -> cols 2,4,6
+    });
+
+    it('2Fx jumps to the 2nd previous occurrence', () => {
+        setContent(['xaxaxa']); // x at cols 0,2,4
+        setCursor({ row: 0, col: 5 });
+        type('2', 'F', 'x');
+        expect(getCursor().col).toBe(2); // going back: 4 (1st), 2 (2nd)
+    });
+
+    it('a count larger than the number of matches leaves the cursor put', () => {
+        setContent(['axbxc']); // only 2 x ahead
+        setCursor({ row: 0, col: 0 });
+        type('9', 'f', 'x');
+        expect(getCursor().col).toBe(0);
+    });
+
+    it('f then Esc cancels with no movement and restores normal command handling', () => {
+        setContent(['abxdef']);
+        setCursor({ row: 0, col: 0 });
+        type('f', 'Escape');
+        expect(getCursor().col).toBe(0);
+        // The next key is handled as a normal command again, not as a find target.
+        press('l');
+        expect(getCursor().col).toBe(1);
+    });
+
+    it('finds a digit target (f3) instead of treating it as a count', () => {
+        setContent(['a3b3c']); // '3' at cols 1 and 3
+        setCursor({ row: 0, col: 0 });
+        type('f', '3');
+        expect(getCursor().col).toBe(1);
+    });
+});


### PR DESCRIPTION
## What

Implements the `f<char>` / `F<char>` find-character motions in `handleNormalMode`, plus a lesson that teaches them.

- `f<char>` — move forward to the next occurrence of `<char>` on the current line.
- `F<char>` — move backward to the previous occurrence.
- Counts repeat the motion: `3fx` jumps to the 3rd `x`.
- If the character isn't on the line, the cursor stays put (Vim behavior).
- The current column is excluded from the search, matching Vim.
- `Esc` cancels a pending `f`/`F`.

## Why

Requested in #36 (from the #3 backlog). `f`/`F` are core intra-line motions that were missing from the engine.

## How

Follows the existing **pending-key** pattern already used by `r` (replace):

- `js/game-state.js`: adds a `pendingFind` field (`{ direction: 1 | -1 }` or `null`) with getter/setter, reset in both `resetGameState()` and `resetLevelState()` (per-session state, see #30).
- `js/vim-commands.js`: `f`/`F` set `pendingFind` and return early so the trigger key is not logged in command history. The next key is consumed as the target. The target is resolved **before** the count-buffer handling, so a digit target (e.g. `f3`) is treated as the character to find rather than as a count.
- `content/lessons/lesson-find-char.json`: new lesson teaching `f`/`F`, slotted after **Line Jumps** via `scripts/inject-order.js`. Its `solution` is replayed by the Golden Suite, so the lesson is provably winnable. (Adding it via `inject-order.js` bumps the `metadata.order` of the lessons that follow it; the generated `content/index.json` and `js/generated-content.js` are regenerated by `scripts/build-content.js`.)

## Tests

New `tests/unit/find-char.test.js` covers `fx`/`Fx`, `3fx`/`2Fx` counts, absent-character no-op, oversized-count no-op, current-column exclusion, `f` then `Esc` cancel, and a digit target (`f3`).

`npm run check` is green end to end:

```
Contract Suite — Errors: 0  Warnings: 0  Infos: 0   (36 lessons, incl. "Find Character (f / F)")
Golden Suite  — PASS 36  FAIL 0                      (incl. "Find Character (f / F)" solution replay)
Vitest        — Test Files 10 passed | Tests 48 passed
eslint        — clean
```

Fixes #36
